### PR TITLE
Feature ocl expressions

### DIFF
--- a/monticore-grammar/src/main/grammars/de/monticore/OCLLogicExpressions.mc4
+++ b/monticore-grammar/src/main/grammars/de/monticore/OCLLogicExpressions.mc4
@@ -83,7 +83,7 @@ external OCLNestedContainer;
 
     */
 
-    ExistsExpr implements Expression =
+    ExistsExpr implements Expression <100> =
         "exists"
         OCLCollectionVarDeclaration?
         OCLNestedContainer?

--- a/monticore-grammar/src/main/grammars/de/monticore/OCLLogicExpressions.mc4
+++ b/monticore-grammar/src/main/grammars/de/monticore/OCLLogicExpressions.mc4
@@ -43,6 +43,11 @@ external OCLNestedContainer;
         "implies"
         rightExpression:Expression;
 
+	SingleLogicalORExpr implements OCLExpression <210> =
+		left:Expression
+		"|"
+		right:Expression;
+
     /** ASTForAllExpr defines a quantified expression for collections e.g.
         "forall x in Y : ...".
         @attribute OCLCollectionVarDeclaration

--- a/monticore-grammar/src/main/grammars/de/monticore/OCLLogicExpressions.mc4
+++ b/monticore-grammar/src/main/grammars/de/monticore/OCLLogicExpressions.mc4
@@ -37,6 +37,7 @@ component grammar OCLLogicExpressions extends de.monticore.ExpressionsBasis, de.
 
 external OCLCollectionVarDeclaration;
 external OCLNestedContainer;
+external OCLDeclaration;
 
     ImpliesExpression implements Expression <200> =
         leftExpression:Expression
@@ -60,7 +61,6 @@ external OCLNestedContainer;
                    The body of forall iteration as an expression.
 
     */
-
     ForallExpr implements Expression <100> =
         "forall"
         OCLCollectionVarDeclaration?
@@ -82,7 +82,6 @@ external OCLNestedContainer;
                    The body of forall iteration as an expression.
 
     */
-
     ExistsExpr implements Expression <100> =
         "exists"
         OCLCollectionVarDeclaration?
@@ -92,4 +91,55 @@ external OCLNestedContainer;
         Expression
         ;
 
+    /** ASTOCLAnyExpr defines iterations with all objects of a collection e.g.
+        any x in set or any Auction.
+        @attribute OCLExpression
+                   A collection defined by an expression.
+    */
+    AnyExpr implements Expression <90> =
+        "any" Expression;
+
+    /** ASTOCLLetinExpr are used to define local vars or methods. The defined
+        vars and methods are visible in the in-expression.
+        @attribute declarations
+                   A list of variable or method declarations.
+        @attribute OCLExpression
+                   An expression where previous declarations are used.
+    */
+    LetinExpr implements Expression <120> =
+        "let" (declarations:OCLDeclaration ";")+
+        "in" Expression
+        |
+        "(" LetinExpr  ")"
+        ;
+
+    /** ASTOCLLetDeclaration represents a list of let-declarations inside of a
+        let-statement. This contains variable- or method-declarations.
+        @attribute declarations
+               List of variable- or method-declarations.
+    */
+    LetDeclaration implements Expression <120> =
+        "let" (declarations:OCLDeclaration ";")+;
+
+
+    /** ASTOCLIterateExpr is used to iterate collections. It differs from
+        Java5-Iterator.
+        Example:
+            iterate{ elem in Auction; int acc=0 : acc = acc+elem.numberOfBids }.
+        @attribute iterationDeclarator
+                   The elements of a collection that will be iterated as an
+                   OCLCollectionVarDeclaration.
+        @attribute initDeclarator
+                   Definiton of a accumulation variable as an OCLDeclaration.
+        @attribute accumulatorName
+                   Name of the accumulation assignment variable.
+        @attribute accumulatorValue
+                   Right hand of the accumulation as an expression.
+    */
+    IterateExpr implements Expression <110> =
+        "iterate" "{"
+        iterationDeclarator:OCLCollectionVarDeclaration ";"
+        initDeclarator:OCLDeclaration ":"
+        accumulatorName:Name "=" accumulatorValue:Expression
+        "}";
 }

--- a/monticore-grammar/src/main/grammars/de/monticore/OCLLogicExpressions.mc4
+++ b/monticore-grammar/src/main/grammars/de/monticore/OCLLogicExpressions.mc4
@@ -1,0 +1,90 @@
+/*
+***************************************************************************************
+Copyright (c) 2017, MontiCore
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+***************************************************************************************
+*/
+
+package de.monticore;
+
+component grammar OCLLogicExpressions extends de.monticore.ExpressionsBasis, de.monticore.common.Common {
+
+external OCLCollectionVarDeclaration;
+external OCLNestedContainer;
+
+    ImpliesExpression implements Expression <200> =
+        leftExpression:Expression
+        "implies"
+        rightExpression:Expression;
+
+    /** ASTForAllExpr defines a quantified expression for collections e.g.
+        "forall x in Y : ...".
+        @attribute OCLCollectionVarDeclaration
+                   List of collection variable declarations, e.g. "forall a in A: ..."
+        @attribute OCLNestedContainer
+                   expresses statements like " forall a in List <..> : ..."
+        @attribute varName
+                   expresses statements like "forall a: ..."
+        @attribute OCLExpression
+                   The body of forall iteration as an expression.
+
+    */
+
+    ForallExpr implements Expression <100> =
+        "forall"
+        OCLCollectionVarDeclaration?
+        OCLNestedContainer?
+        varName:Name?
+        ":"
+        Expression
+        ;
+
+    /** ASTExistsExpr defines a quantified expression for collections e.g.
+        "exists x in Y : ...".
+        @attribute OCLCollectionVarDeclaration
+                   List of collection variable declarations, e.g. "exists a in A: ..."
+        @attribute OCLNestedContainer
+                   expresses statements like "exists a in List <..> : ..."
+        @attribute varName
+                   expresses statements like "exists a: ..."
+        @attribute OCLExpression
+                   The body of forall iteration as an expression.
+
+    */
+
+    ExistsExpr implements Expression =
+        "exists"
+        OCLCollectionVarDeclaration?
+        OCLNestedContainer?
+        varName:Name?
+        ":"
+        Expression
+        ;
+
+}

--- a/monticore-grammar/src/main/grammars/de/monticore/SetExpressions.mc4
+++ b/monticore-grammar/src/main/grammars/de/monticore/SetExpressions.mc4
@@ -1,0 +1,74 @@
+/*
+***************************************************************************************
+Copyright (c) 2017, MontiCore
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+***************************************************************************************
+*/
+
+package de.monticore;
+
+component grammar SetExpressions extends de.monticore.ExpressionsBasis {
+
+
+    IsInExpression implements Expression <190> =
+        leftExpression:Expression
+        "isin"
+        rightExpression:Expression;
+
+    SetInExpression implements Expression <190> =
+        leftExpression:Expression
+        "in"
+        rightExpression:Expression;
+
+    UnionExpression implements Expression <180> =
+        leftExpression:Expression
+        "union"
+        rightExpression:Expression;
+
+    IntersectionExpression implements Expression <180> =
+        leftExpression:Expression
+        "intersect"
+        rightExpression:Expression;
+
+    SetAndExpression implements Expression <130> =
+        leftExpression:Expression
+        "setand"
+        rightExpression:Expression;
+
+    SetOrExpression implements Expression <130> =
+        leftExpression:Expression
+        "setor"
+        rightExpression:Expression;
+
+    SetXOrExpression implements Expression <130> =
+        leftExpression:Expression
+        "setxor"
+        rightExpression:Expression;
+
+}

--- a/monticore-grammar/src/test/grammars/de/monticore/TestOCLLogicExpressions.mc4
+++ b/monticore-grammar/src/test/grammars/de/monticore/TestOCLLogicExpressions.mc4
@@ -1,0 +1,6 @@
+package de.monticore;
+
+grammar TestOCLLogicExpressions extends de.monticore.OCLLogicExpressions, de.monticore.CommonExpressions {
+	PrimaryExpression implements Expression<20000> = 
+	  Name;
+}

--- a/monticore-grammar/src/test/grammars/de/monticore/TestSetExpressions.mc4
+++ b/monticore-grammar/src/test/grammars/de/monticore/TestSetExpressions.mc4
@@ -1,0 +1,6 @@
+package de.monticore;
+
+grammar TestSetExpressions extends de.monticore.SetExpressions, de.monticore.CommonExpressions {
+	PrimaryExpression implements Expression<20000> = 
+	  Name;
+}


### PR DESCRIPTION
Move expressions from OCL to more generic expression grammars

- SetExpressions contains expressions on sets, like union/intersect etc.

- OCLLogicExpressions contains logical expressions for OCL, like implies/forall etc.