### PR TITLE
change OCLExpressions to use external Type

### DIFF
--- a/monticore-grammar/src/main/grammars/de/monticore/OCLExpressions.mc4
+++ b/monticore-grammar/src/main/grammars/de/monticore/OCLExpressions.mc4
@@ -34,13 +34,14 @@ SUCH DAMAGE.
 
 package de.monticore;
 
-component grammar OCLExpressions extends de.monticore.common.Common, de.monticore.CommonExpressions,
-                                            de.monticore.SetExpressions, de.monticore.ShiftExpressions {
+component grammar OCLExpressions extends de.monticore.CommonExpressions,
+                           de.monticore.SetExpressions, de.monticore.ShiftExpressions {
 
 external EDeclaration;
+external EType;
 
     InstanceOfExpression implements Expression <50> =
-        leftExpression:Expression operator:"instanceof" Type;
+        leftExpression:Expression operator:"instanceof" EType;
 
     TypeIfExpr implements Expression <100> =
         "typeif" condition:Expression
@@ -147,7 +148,7 @@ external EDeclaration;
         "}";
 
     TypeCastExpression implements Expression <200> =
-    	"(" Type ")" Expression;
+    	"(" EType ")" Expression;
 
     ParenthizedExpression implements Expression <10> =
         "(" Expression ")"
@@ -157,11 +158,10 @@ external EDeclaration;
         shortform of "Auction a in Auction.allInstances").
     */
     InExpr implements Expression <50> =
-		Type?
+		EType?
 		varNames:(Name || ",")+
 		("in" Expression)?
         ;
-
 
     /*============================= OCL PRIMARYS =============================*/
 
@@ -229,7 +229,7 @@ external EDeclaration;
                    Optional Qualification.
     */
     OCLComprehensionPrimary implements OCLPrimary  <40> =
-        Type?
+        EType?
         "{" expression:OCLComprehensionExpr? "}"
         ("." qualification:OCLPrimary)?
         ;

--- a/monticore-grammar/src/main/java/de/monticore/expressions/prettyprint/OCLExpressionsPrettyPrinter.java
+++ b/monticore-grammar/src/main/java/de/monticore/expressions/prettyprint/OCLExpressionsPrettyPrinter.java
@@ -54,8 +54,8 @@ public class OCLExpressionsPrettyPrinter implements OCLExpressionsVisitor {
     @Override
     public void handle(ASTInExpr node) {
         CommentPrettyPrinter.printPreComments(node, getPrinter());
-        if(node.typeIsPresent())
-            node.getType().get().accept(getRealThis());
+        if(node.eTypeIsPresent())
+            node.getEType().get().accept(getRealThis());
 
         Iterator iter = node.getVarNames().iterator();
         getPrinter().print(iter.next());

--- a/monticore-grammar/src/test/grammars/de/monticore/TestOCLExpressions.mc4
+++ b/monticore-grammar/src/test/grammars/de/monticore/TestOCLExpressions.mc4
@@ -10,4 +10,6 @@ grammar TestOCLExpressions extends de.monticore.OCLExpressions {
 
     EDeclaration implements Expression =
         (public:"public" | private:"private")? type:Name varName:Name;
+
+    EType = Name;
 }


### PR DESCRIPTION
This is needed because OCL uses NumberUnit and this of now collides with the Types language here