### PR TITLE
Fix swapped argument order in GettingStarted.md

### DIFF
--- a/00.org/Explanations/CHANGELOG.md
+++ b/00.org/Explanations/CHANGELOG.md
@@ -492,4 +492,3 @@ released: 07.05.2020
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/00.org/Explanations/FAQ.md
+++ b/00.org/Explanations/FAQ.md
@@ -44,4 +44,3 @@ Remember that all Maven modules are independent units. By default, they are not 
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/00.org/Explanations/StatusOfGrammars.md
+++ b/00.org/Explanations/StatusOfGrammars.md
@@ -68,4 +68,3 @@ A comment of the following form within the grammar defines this status:
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md
+++ b/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md
@@ -121,5 +121,3 @@ compatible with MontiCores licenses:
 * see also [**MontiCore Reference Manual**](https://www.monticore.de/)
 
 * [MontiCore project](../../README.md) - MontiCore
-
-

--- a/README.md
+++ b/README.md
@@ -173,4 +173,3 @@ For details see [Licenses](00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md).
 * [**MontiCore Core Grammar Library**](https://github.com/MontiCore/monticore/blob/dev/monticore-grammar/src/main/grammars/de/monticore/Grammars.md)
 * [Best Practices](https://monticore.github.io/monticore/docs/BestPractices/)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
-

--- a/docs/BestPractices-CLI.md
+++ b/docs/BestPractices-CLI.md
@@ -2,7 +2,7 @@
 
 # MontiCore Best Practices - Designing Tools for Command Line Interfaces
 
-[[_TOC_]]
+
 
 Some DSLs require a tool to enable general accessibility via the command line interface (CLI). 
 When designing a tool, we recommend some standard guidelines.
@@ -166,4 +166,3 @@ might a good argument to do it differently.
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/docs/BestPractices-Errors.md
+++ b/docs/BestPractices-Errors.md
@@ -2,7 +2,7 @@
 
 # MontiCore Best Practices - Understanding Errors, Defining Errors
 
-[[_TOC_]]
+
 
 Errors happen.
 Some happen because of faults in the code (we call that internal errors),
@@ -44,4 +44,3 @@ they could be taken for something else).
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/docs/BestPractices-Language-Design.md
+++ b/docs/BestPractices-Language-Design.md
@@ -235,4 +235,3 @@ of which has its own advantages and disadvantages:
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/docs/BestPractices-Symbols-Scopes.md
+++ b/docs/BestPractices-Symbols-Scopes.md
@@ -143,4 +143,3 @@ intermediate step between the tools providing and reading the symbol tables.
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/docs/BestPractices-Syntax-Design.md
+++ b/docs/BestPractices-Syntax-Design.md
@@ -2,7 +2,7 @@
 
 # MontiCore Best Practices - Concrete and Abstract Syntax
 
-[[_TOC_]]
+
 
 [MontiCore](https://www.monticore.de) provides a number of options to design 
 languages, access and modify the abstract syntax tree, and produce output files.
@@ -302,4 +302,3 @@ A component grammar is meant for extension. MontiCore therefore provides five(!)
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -44,4 +44,3 @@ of the reference manual.
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/docs/BuildMontiCore.md
+++ b/docs/BuildMontiCore.md
@@ -74,4 +74,3 @@ lasting tasks.
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/docs/DevelopedLanguages.md
+++ b/docs/DevelopedLanguages.md
@@ -165,4 +165,3 @@ development. See language definition and usage method in
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/docs/Download.md
+++ b/docs/Download.md
@@ -11,7 +11,7 @@ The following tools for MontiCore can be used from the command line and thus e.g
 * The [FeatureConfiguration tool](https://www.monticore.de/download/MCFeatureConfiguration.jar) for a [Feature Diagram language](https://github.com/MontiCore/feature-diagram)
 * The [FeatureConfigurationPartial tool](https://www.monticore.de/download/MCFeatureConfigurationPartial.jar) for a [Feature Diagram language](https://github.com/MontiCore/feature-diagram)
 * The [FeatureDiagram tool](https://www.monticore.de/download/MCFeatureDiagram.jar) for a [Feature Diagram language](https://github.com/MontiCore/feature-diagram)
-* The [MLC tool](https://www.monticore.de/download/MCMLC.jar) for grouping [Monticore Language Components](https://git.rwth-aachen.de/monticore/languages/mlc)
+* The [MLC tool](https://www.monticore.de/download/MCMLC.jar) for grouping [Monticore Language Components (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/mlc)
 * The [OCL tool](https://www.monticore.de/download/MCOCL.jar) for an [Object Constraint Language](https://github.com/MontiCore/ocl)
 * The [OD4Data tool](https://www.monticore.de/download/MCOD4Data.jar) for an [Object Diagram language](https://github.com/MontiCore/object-diagram)
 * The [OD4Report tool](https://www.monticore.de/download/MCOD4Report.jar) for an [Object Diagram language](https://github.com/MontiCore/object-diagram)

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1102,7 +1102,7 @@ including the `Automata` tool class `AutomataTool`. For running the
 
 ```bash
 java -cp "src/;out/;hwc/;monticore-rt.jar" \
-                    -i automata.AutomataTool example/PingPong.aut \
+                    automata.AutomataTool -i example/PingPong.aut \
                     -s st/PingPong.autsym
 ```
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -316,7 +316,7 @@ Passing the argument `-mp` enables specifying the paths to directories
 containing paths to grammars and Java classes that are imported by the 
 processed grammar and the related tooling. In this case, the archive 
 `monticore-rt.jar` contains the grammars and handwritten extensions
-of the [monticore standard library](https://git.rwth-aachen.de/monticore/monticore/-/tree/dev/monticore-grammar/src/main).
+of the [monticore standard library (not yet publicly available)](https://git.rwth-aachen.de/monticore/monticore/-/tree/dev/monticore-grammar/src/main).
 More information about the standard library can be found in 
 [Chapters 17- 20 of the handbook](https://www.monticore.de/handbook.pdf).
 
@@ -1328,4 +1328,3 @@ the project again.
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/docs/Languages.md
+++ b/docs/Languages.md
@@ -3,7 +3,7 @@
 
 # MontiCore Languages of Level II - an Overview
 
-[[_TOC_]]
+
 
 [MontiCore](https://www.monticore.de) is a language workbench
 with an explicit notion of language components. It uses 
@@ -138,7 +138,7 @@ featurediagram MyPhones {
 
 
 
-### [GUI DSL](https://git.rwth-aachen.de/monticore/languages/gui-dsl) (Alpha: Intention to become stable)
+### [GUI DSL (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/gui-dsl) (Alpha: Intention to become stable)
 * Language for textual definition of Graphical User Interfaces of Web
 Applications
 * GUI DSL covers GUI elements and relevant configuration, which include
@@ -149,24 +149,24 @@ the language represents graphical views or their parts, omitting smaller details
 of style definition and simplifying connection between graphical elements and
 data sources.
 * Currently, new version of the `GUIDSL` is being developed:
-  * [Basis grammar `GUIBasis`](https://git.rwth-aachen.de/monticore/languages/gui-dsl/-/blob/dev/src/main/grammars/de/monticore/GUIBasis.mc4)
+  * [Basis grammar `GUIBasis` (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/gui-dsl/-/blob/dev/src/main/grammars/de/monticore/GUIBasis.mc4)
 includes constructs for general visualization component definitions, control
 statements and components for layout description.
-  * [Example models](https://git.rwth-aachen.de/monticore/languages/gui-dsl/-/tree/dev/src/test/resources/pages/room)
+  * [Example models (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/gui-dsl/-/tree/dev/src/test/resources/pages/room)
 can be found in the same repository.
-  * [Main grammar `GUIDSL`](https://git.rwth-aachen.de/monticore/languages/gui-dsl/-/blob/dev/src/main/grammars/de/monticore/GUIDSL.mc4)
+  * [Main grammar `GUIDSL` (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/gui-dsl/-/blob/dev/src/main/grammars/de/monticore/GUIDSL.mc4)
 includes basic concepts and more specific implementation of component
 configuration.
 * In projects legacy version is currently used:
-  * Examples: [**MaCoCo**](https://git.rwth-aachen.de/macoco/implementation),
+  * Examples: [**MaCoCo** (not yet publicly available)](https://git.rwth-aachen.de/macoco/implementation),
               Ford
-  * [Main grammar `GUIDSL`](https://git.rwth-aachen.de/monticore/languages/gui-dsl/-/blob/master/src/main/grammars/GUIDSL.mc4)
+  * [Main grammar `GUIDSL` (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/gui-dsl/-/blob/master/src/main/grammars/GUIDSL.mc4)
 includes definitions of MontiGem visualisation components, which are based on
 abstract concepts, described in
-[core grammar `GUIDSLCore`](https://git.rwth-aachen.de/monticore/languages/gui-dsl/-/blob/master/src/main/grammars/GUIDSLCore.mc4).
-[*Detailed description*](https://git.rwth-aachen.de/monticore/languages/gui-dsl/-/blob/master/src/main/grammars/GUIDSL.md)
+[core grammar `GUIDSLCore` (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/gui-dsl/-/blob/master/src/main/grammars/GUIDSLCore.mc4).
+[*Detailed description* (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/gui-dsl/-/blob/master/src/main/grammars/GUIDSL.md)
 and
-[*documentation*](https://git.rwth-aachen.de/monticore/languages/gui-dsl/wikis/home).
+[*documentation* (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/gui-dsl/wikis/home).
 
 
 ### [MontiCore Grammar](https://github.com/MontiCore/monticore/tree/dev/monticore-grammar/src/main/grammars/de/monticore/grammar) (MontiCore Stable)
@@ -232,7 +232,7 @@ and
   [*detailed description*](https://github.com/MontiCore/json/blob/develop/src/main/grammars/de/monticore/lang/json.md)
 
 
-### [MontiArc](https://git.rwth-aachen.de/monticore/montiarc/core) (MontiCore Stable) 
+### [MontiArc (not yet publicly available)](https://git.rwth-aachen.de/monticore/montiarc/core) (MontiCore Stable) 
 * MontiArc is an architecture and behavior modeling language and framework 
     that provides a platform independent structure and behavior 
     modeling language with an extensible code generation framework.
@@ -274,9 +274,9 @@ component InteriorLight {                           // MontiArc language
   language a concrete timing, such as formally grounded by Focus, 
   should be added.
 * Main grammar 
-  [`MontiArc.mc4`](https://git.rwth-aachen.de/monticore/montiarc/core/-/blob/develop/languages/montiarc-fe/src/main/grammars/MontiArc.mc4)
+  [`MontiArc.mc4` (not yet publicly available)](https://git.rwth-aachen.de/monticore/montiarc/core/-/blob/develop/languages/montiarc-fe/src/main/grammars/MontiArc.mc4)
   and 
-  [*detailed description*](https://git.rwth-aachen.de/monticore/montiarc/core/-/blob/develop/languages/montiarc-fe/src/main/grammars/MontiArc.md)
+  [*detailed description* (not yet publicly available)](https://git.rwth-aachen.de/monticore/montiarc/core/-/blob/develop/languages/montiarc-fe/src/main/grammars/MontiArc.md)
 
 
 ### [OCL/P](https://github.com/monticore/OCL) (MontiCore Stable)
@@ -469,7 +469,7 @@ statechart Door {
 * [*Detailed description*](https://github.com/MontiCore/statecharts/blob/dev/src/main/grammars/de/monticore/Statecharts.md) 
 
 
-### [SysML_2](https://git.rwth-aachen.de/monticore/languages/sysml2/sysml2official) (Alpha: Intention to become stable)
+### [SysML_2 (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/sysml2/sysml2official) (Alpha: Intention to become stable)
 * MontiCore languages for parsing artifacts of the SysML 2 language family. 
   Examples:
 ```
@@ -503,12 +503,12 @@ package 'Coffee' {                      // a SysML activity diagram
 * SysML 2 covers **ADs**, **BDDs**, **IBDs**, **PackageDiagrams**, 
   **ParametricDiagrams**, **RequirementDiagrams**, **SDs**, **SMDs**, 
   **UseCaseDiagrams**, and general **SysMLBasics**
-* [Main grammars](https://git.rwth-aachen.de/monticore/languages/sysml2/sysml2official/-/tree/master/src%2Fmain%2Fgrammars%2Fde%2Fmonticore%2Flang%2Fsysml)
+* [Main grammars (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/sysml2/sysml2official/-/tree/master/src%2Fmain%2Fgrammars%2Fde%2Fmonticore%2Flang%2Fsysml)
   and 
-  [*detailed description*](https://git.rwth-aachen.de/monticore/languages/sysml2/sysml2official/-/blob/master/src/main/grammars/de/monticore/lang/sysml/sysml2.md)
+  [*detailed description* (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/sysml2/sysml2official/-/blob/master/src/main/grammars/de/monticore/lang/sysml/sysml2.md)
 
 
-### [Tagging](https://git.rwth-aachen.de/monticore/EmbeddedMontiArc/languages/Tagging) (Alpha: Intention to become stable)
+### [Tagging (not yet publicly available)](https://git.rwth-aachen.de/monticore/EmbeddedMontiArc/languages/Tagging) (Alpha: Intention to become stable)
 * **Tags** are known e.g. from the UML and SysML and mainly used to add
   extra information to a model element. 
   Normally tags (and **stereotypes**) are inserted within the models,
@@ -532,12 +532,12 @@ package 'Coffee' {                      // a SysML activity diagram
     * a tagging language TL (dependent on the tag schema models written in TSL)
 * Because tagging models can e.g. be used as configuration techniques 
   in a code generator, appropriate infrastructure is generated as well.
-* Some [**tagging language examples**](https://git.rwth-aachen.de/monticore/EmbeddedMontiArc/languages/Tagging-Examples)
+* Some [**tagging language examples** (not yet publicly available)](https://git.rwth-aachen.de/monticore/EmbeddedMontiArc/languages/Tagging-Examples)
 * Although concrete languages (and their grammars) are themselves generated,
   there is a 
-  [main grammar `ocl.monticore.lang.Tagging`](https://git.rwth-aachen.de/monticore/EmbeddedMontiArc/languages/Tagging/-/blob/master/src/main/grammars/de/monticore/lang/Tagging.mc4),
+  [main grammar `ocl.monticore.lang.Tagging` (not yet publicly available)](https://git.rwth-aachen.de/monticore/EmbeddedMontiArc/languages/Tagging/-/blob/master/src/main/grammars/de/monticore/lang/Tagging.mc4),
   where the tagging language is derived from.
-  See also [*detailed description*](https://git.rwth-aachen.de/monticore/EmbeddedMontiArc/languages/Tagging/-/blob/master/src/main/grammars/de/monticore/lang/Tagging.md)
+  See also [*detailed description* (not yet publicly available)](https://git.rwth-aachen.de/monticore/EmbeddedMontiArc/languages/Tagging/-/blob/master/src/main/grammars/de/monticore/lang/Tagging.md)
 
 ### [Use Case Diagrams](https://github.com/MontiCore/ucd)  (MontiCore stable) 
 * A textual use case diagram (UCD) language.
@@ -621,11 +621,11 @@ public void print(String name) {
 
 
 
-### [Java](https://git.rwth-aachen.de/monticore/javaDSL) (Beta: In Stabilization) 
+### [Java (not yet publicly available)](https://git.rwth-aachen.de/monticore/javaDSL) (Beta: In Stabilization) 
 * This is the full Java' Language (as Opposed to JavaLight).
-* Main Grammar [`JavaDSL`](https://git.rwth-aachen.de/monticore/javaDSL/-/blob/dev/javaDSL/src/main/grammars/de/monticore/java/JavaDSL.mc4)
+* Main Grammar [`JavaDSL` (not yet publicly available)](https://git.rwth-aachen.de/monticore/javaDSL/-/blob/dev/javaDSL/src/main/grammars/de/monticore/java/JavaDSL.mc4)
   and
-  [*detailed description*](https://git.rwth-aachen.de/monticore/javaDSL/-/blob/dev/javaDSL/src/main/grammars/de/monticore/java/JavaDSL.md).
+  [*detailed description* (not yet publicly available)](https://git.rwth-aachen.de/monticore/javaDSL/-/blob/dev/javaDSL/src/main/grammars/de/monticore/java/JavaDSL.md).
 
 
 ## Further Information
@@ -637,4 +637,3 @@ public void print(String name) {
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/monticore-grammar/src/main/grammars/de/monticore/Grammars.md
+++ b/monticore-grammar/src/main/grammars/de/monticore/Grammars.md
@@ -4,7 +4,7 @@
 
 # MontiCore Grammars for Expressions, Literals and Types - an Overview
 
-[[_TOC_]]
+
 
 [MontiCore](https://www.monticore.de) is a language workbench. It uses 
 grammars as primary mechanism to describe DSLs. The extended 
@@ -109,7 +109,7 @@ Language component MCArrayTypes provides
 possibilities to add arrays, such as `Person[]` or `int[][]`.
 
 
-### [SIUnitTypes4Math.mc4](https://git.rwth-aachen.de/monticore/languages/siunits) for Physical SI Units (stable)
+### [SIUnitTypes4Math.mc4 (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/siunits) for Physical SI Units (stable)
 
 The known units `s, m, kg, A, K, mol, cd` from the international system of 
 units (SI Units) and  their combinations, such as `km/h` or `mg`, etc. can 
@@ -121,7 +121,7 @@ e.g. stored in a `m/s`-based variable.
 The grammar resides in the [MontiCore/SIunits](https://github.com/MontiCore/siunits/blob/master/src/main/grammars/de/monticore/SIUnits.md) project.
 
 
-### [SIUnitTypes4Computing.mc4](https://git.rwth-aachen.de/monticore/languages/siunits) for Physical SI Units (stable)
+### [SIUnitTypes4Computing.mc4 (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/siunits) for Physical SI Units (stable)
 
 Includes the types from `SIUnitTypes4Math`(see above), like `km/h`, but also allows to add a
 resolution, such as `km/h<int>`. Here SI Unit types, 
@@ -131,7 +131,7 @@ such as `int`, `long`, `double`, `float` as argument.
 The grammar resides in the [MontiCore/SIunits](https://github.com/MontiCore/siunits/blob/master/src/main/grammars/de/monticore/SIUnits.md) project.
 
 
-### [RegExType.mc4](https://git.rwth-aachen.de/monticore/languages/regex) (stable)
+### [RegExType.mc4 (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/regex) (stable)
 
 Embedded in `R"..."` a regular expressions
 can be used as ordinary type to constrain the values allowed for stored variables, attributes, 
@@ -140,7 +140,7 @@ A typecheck for these types can only be executed at runtime and e.g. issue
 exceptions (or trigger repair functions) if violated. The static typecheck only uses `String` as 
 underlying carrier type.
 
-This grammar resides in the [MontiCore/RegEx][RegEx] project.
+This grammar resides in the [MontiCore/RegEx (not yet publicly available)][RegEx] project.
 
 
 ## Symbols: List of Grammars in package `de.monticore.symbols`
@@ -224,33 +224,33 @@ expressions.
 like <<, >>, >>>, &, ^ and |
 
 
-### [OCLExpressions.mc4][OCL-OCLExpressions] (stable)
+### [OCLExpressions.mc4 (not yet publicly available)][OCL-OCLExpressions] (stable)
 * This grammar defines expressions typical to UMLs OCL .
   OCL expressions can savely be composed if with other forms of expressions  
   given in the MontiCore core project (i.e. as conservative extension).
 * It contains various logical operations, such as quantifiers, 
   the `let` and the `@pre` construct, and a transitive closure for 
   associations, as discussed in [Rum17,Rum17].
-* This grammar resides in the [MontiCore/OCL][OCL] project.
+* This grammar resides in the [MontiCore/OCL (not yet publicly available)][OCL] project.
 
-### [SetExpressions.mc4][OCL-SetExpressions] (stable)
+### [SetExpressions.mc4 (not yet publicly available)][OCL-SetExpressions] (stable)
 * This grammar defines set expressions like set union, intersection etc.
 these operations are typical for a logic with set operations, like 
 UML's OCL. These operators are usually infix and are thus more intuitive
 as they allow math oriented style of specification.
 * Most of these operators are in principle executable, so it might be interesting to include them in a high level programming language (see e.g. Haskell)
-* This grammar resides in the [MontiCore/OCL][OCL] project.
+* This grammar resides in the [MontiCore/OCL (not yet publicly available)][OCL] project.
 
 
-### [OptionalOperators.mc4][OCL-OptionalOperators] (stable)
+### [OptionalOperators.mc4 (not yet publicly available)][OCL-OptionalOperators] (stable)
 * This grammar defines nine operators dealing with optional values, e.g. defined by 
   `java.lang.Optional`. The operators are also called *Elvis operators*.
 * E.g.: `val ?: 0W`     equals to   `val.isPresent ? val.get : 0W`
 * `x ?>= y` equals `x.isPresent && x.get >= y` 
-* This grammar resides in the [MontiCore/OCL][OCL] project.
+* This grammar resides in the [MontiCore/OCL (not yet publicly available)][OCL] project.
 
 
-### [SIUnits.mc4](https://git.rwth-aachen.de/monticore/languages/siunits) for Physical SI Units (stable)
+### [SIUnits.mc4 (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/siunits) for Physical SI Units (stable)
 * This grammar the international system of units (SI units), based on 
   the basis units `s, m, kg, A, K, mol, cd`, 
   provides a variety of derived units, and can be refined using prefixes such 
@@ -291,7 +291,8 @@ various forms of literals.
 * This grammar defines the typical literals for an expression language, such as 
   characters: 'c', Strings "text", booleans: "true", "null", or numbers 10, 
   -23, 48l, 23.1f.
-* Strings and characters use the Java-like escapes like "\n".
+* Strings and characters use the Java-like escapes like "
+".
 * Each defined nonterminal is extended by a conversion function `getValue()`
   of appropriate type and a retrieve function `getSource()` for a text representation
   of the literal.
@@ -307,7 +308,7 @@ various forms of literals.
 * Like above `getValue()` and `getSource()` allow to retrive the content
   as value resp. as text string.
 
-### [SIUnitLiterals.mc4](https://git.rwth-aachen.de/monticore/languages/siunits) for Physical SI Units (stable)
+### [SIUnitLiterals.mc4 (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/siunits) for Physical SI Units (stable)
 
 Provides concrete values, such as `5.3 km/h`or `7 mg` for the international system of 
 units (SI Units). 
@@ -371,12 +372,12 @@ is inspired by Java (actually subset of Java). Some example statements:
 
 several other grammars are also available:
 
-### [RegularExpressions.mc4](https://git.rwth-aachen.de/monticore/languages/regex) (stable)
+### [RegularExpressions.mc4 (not yet publicly available)](https://git.rwth-aachen.de/monticore/languages/regex) (stable)
 * This grammar defines regular expressions (RegEx) as used in Java (see e.g. `java.util.regex.Pattern`).
 * It provides common regex tokens such as 
   * character classes, e.g., lowercase letters (`[a-z]`), the letters a, b, 
     and c (`[abc]`)
-  * anchors, e.g., start of line (`^`), end of line (`$`), word boundary (`\b`),
+  * anchors, e.g., start of line (`^`), end of line (`$`), word boundary (``),
   * quantifiers, e.g., zero or one (`?`), zero or more (`*`), exactly 3 (`{3}`),
   * RegEx also supports to capture groups and referencing these captured groups 
   in replacements.  
@@ -387,7 +388,7 @@ several other grammars are also available:
   the nonterminal `RegularExpression` is can be used in aother places of a language
   e.g. we do that as additional 
   restriction for String values in input/output channels in architectural langages.
-* This grammar resides in the [MontiCore/RegEx][RegEx] project
+* This grammar resides in the [MontiCore/RegEx (not yet publicly available)][RegEx] project
 
 ### [Cardinality.mc4](Cardinality.mc4) (stable)
 * This grammar defines UML Cardinalities of forms ``*``, ``[n..m]`` or ``[n..*]``.

--- a/monticore-grammar/src/main/grammars/de/monticore/JavaLight.md
+++ b/monticore-grammar/src/main/grammars/de/monticore/JavaLight.md
@@ -39,7 +39,7 @@ Expressions are supported in all their forms.
 
 ## Grammar
 
-- The main grammar file is [`de.monticore.JavaLight`][JavaLight].
+- The main grammar file is [`de.monticore.JavaLight` (not yet publicly available)][JavaLight].
   It deals with the definition of the _method_ and _constructor signatures_, 
   and the _annotations_, while it reuses MontiCore's library components 
   `AssignmentExpressions`, `JavaClassExpressions`, `MCCommonStatements`, 
@@ -136,7 +136,7 @@ The CoCos of embedded languages, such as statements and expressions are defined 
 
 
 ### PrettyPrinter
-- The basic pretty printer for JavaLight is [`de.monticore.prettyprint.JavaLightPrettyPrinter`][PrettyPrinter]
+- The basic pretty printer for JavaLight is [`de.monticore.prettyprint.JavaLightPrettyPrinter` (not yet publicly available)][PrettyPrinter]
 
 - When the expression language is used as high-level language, it might make sense to map attribute
   access to get-functions respectively also use set-functions for modification.
@@ -155,4 +155,3 @@ The CoCos of embedded languages, such as statements and expressions are defined 
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [License definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/monticore-grammar/src/main/grammars/de/monticore/literals/Literals.md
+++ b/monticore-grammar/src/main/grammars/de/monticore/literals/Literals.md
@@ -47,4 +47,3 @@ This Grammar extends MCCommonLiterals.mc4 and includes rules to parse:
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/monticore-grammar/src/main/grammars/de/monticore/types/Types.md
+++ b/monticore-grammar/src/main/grammars/de/monticore/types/Types.md
@@ -78,4 +78,3 @@ possibilities to add arrays, such as `Person[]` or `int[][]`.
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/monticore-grammar/src/main/java/de/monticore/types/check/TypeCheck.md
+++ b/monticore-grammar/src/main/java/de/monticore/types/check/TypeCheck.md
@@ -148,4 +148,3 @@ An example for the case that a plus expression needs to return 'int' can be foun
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/monticore-runtime/src/main/java/de/monticore/symboltable/Symboltable.md
+++ b/monticore-runtime/src/main/java/de/monticore/symboltable/Symboltable.md
@@ -2,7 +2,7 @@
 
 # Documentation of the Symbol Table Infrastructure
 
-[[_TOC_]]
+
 
 ## Conceptual Model of Symbol Tables
 * What is a symbol? 
@@ -256,4 +256,3 @@ adapts the foreign symbol (e.g., CDClassSymbol) to the expected symbol (e.g., St
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/monticore-test/01.experiments/hooks/ReadMe.md
+++ b/monticore-test/01.experiments/hooks/ReadMe.md
@@ -63,4 +63,3 @@ unit tests.
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-

--- a/monticore-test/01.experiments/templates/ReadMe.md
+++ b/monticore-test/01.experiments/templates/ReadMe.md
@@ -76,4 +76,3 @@ unit tests.
 * [Best Practices](https://github.com/MontiCore/monticore/blob/dev/docs/BestPractices.md)
 * [Publications about MBSE and MontiCore](https://www.se-rwth.de/publications/)
 * [Licence definition](https://github.com/MontiCore/monticore/blob/master/00.org/Licenses/LICENSE-MONTICORE-3-LEVEL.md)
-


### PR DESCRIPTION
To run the AutomataTool, the "-i" should be after the class to run, such that it is a parameter given to the main method of the AutomataTool, not a parameter given to the java runtime, which leads to an error.