### PR TITLE
BugFix: delegate groovy classloader to reduce the impact of JDK-8078641 

### DIFF
--- a/monticore-generator/src/main/java/de/monticore/DelegatingClassLoader.java
+++ b/monticore-generator/src/main/java/de/monticore/DelegatingClassLoader.java
@@ -1,0 +1,96 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * Another clean-up for JDK-8078641:
+ * Groovy uses MethodHandle.asTypeCache which keeps a reference to the
+ * "Script1.groovy" (interpreted execution script) alive,
+ * which in term retains a classloader reference.
+ * => The classloader of the groovy script will NOT be unloaded as long as
+ * the MethodHandleImpl cache is present.
+ * If the classloader of the script is an (Isolated)URLClassLoader,
+ * this means all loaded classes of said classloader remain loaded.
+ * --
+ * This class holds the actual classloader as a reference and delegates
+ * all calls to it.
+ * When {@link #close()} is called, only the reference to the delegate is
+ * cleared, the close call is not delegated
+ *
+ * @deprecated Included with se-commons-groovy 7.8.0+
+ */
+@Deprecated
+public class DelegatingClassLoader extends ClassLoader implements Closeable {
+  protected final WeakReference<ClassLoader> delegate;
+  // The actual method is not stored as a reference as it otherwise might be unloaded prematurely
+  protected Method delegateLoadClass;
+
+  public DelegatingClassLoader(ClassLoader delegate) {
+    this.delegate = new WeakReference<>(delegate);
+    try {
+      // The loadClass method is protected, but used by Groovy
+      this.delegateLoadClass = ClassLoader.class.getDeclaredMethod("loadClass", String.class, boolean.class);
+      this.delegateLoadClass.setAccessible(true);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Class<?> loadClass(String name) throws ClassNotFoundException {
+    return Objects.requireNonNull(delegate.get()).loadClass(name);
+  }
+
+  @Override
+  protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    // This method is unfortunately protected, but used by the Groovy compiler
+    // Only classes exposed to groovy are loaded using this method (<1000 calls)
+    try {
+      return (Class<?>) this.delegateLoadClass.invoke(delegate.get(), name, resolve);
+    } catch (InvocationTargetException | IllegalAccessException e) {
+      if (e.getCause() instanceof ClassNotFoundException) {
+        // rethrow ClassNotFoundExceptions
+        throw (ClassNotFoundException) e.getCause();
+      }
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public URL getResource(String name) {
+    return Objects.requireNonNull(delegate.get()).getResource(name);
+  }
+
+  @Override
+  public Enumeration<URL> getResources(String name) throws IOException {
+    return Objects.requireNonNull(delegate.get()).getResources(name);
+  }
+
+  @Override
+  public Stream<URL> resources(String name) {
+    return Objects.requireNonNull(delegate.get()).resources(name);
+  }
+
+  @Override
+  public InputStream getResourceAsStream(String name) {
+    return Objects.requireNonNull(delegate.get()).getResourceAsStream(name);
+  }
+
+  @Override
+  public void close() throws IOException {
+    // Do not delegate the close call!
+    // only clean up the reference to the delegate
+    this.delegate.clear();
+    this.delegateLoadClass = null;
+  }
+}

--- a/monticore-generator/src/main/java/de/monticore/MontiCoreScript.java
+++ b/monticore-generator/src/main/java/de/monticore/MontiCoreScript.java
@@ -1480,6 +1480,7 @@ public class MontiCoreScript extends Script implements GroovyRunner {
       List<MCPath> mcPaths = new ArrayList<>();
       Optional<MontiCoreReports> reportsOpt = Optional.empty();
 
+      DelegatingClassLoader groovyClassLoader = new DelegatingClassLoader(this.getClass().getClassLoader());
       try {
         if(config.isPresent()) {
           MontiCoreConfiguration mcConfig = MontiCoreConfiguration.withConfiguration(config.get());
@@ -1527,6 +1528,9 @@ public class MontiCoreScript extends Script implements GroovyRunner {
           // the "force" parameter, which is always true
           builder.addVariable("force", true);
         }
+        // Use a delegating classloader for groovy to reduce
+        // the impact of JDK-8078641
+        builder.withClassLoader(groovyClassLoader);
 
         GroovyInterpreter g = builder.build();
         g.evaluate(script);
@@ -1537,8 +1541,12 @@ public class MontiCoreScript extends Script implements GroovyRunner {
         for(MCPath mcPath: mcPaths) {
           mcPath.close();
         }
-        if(reportsOpt.isPresent()) {
-          reportsOpt.get().close();
+        // Notify the reporters about flushing & closing their file handles
+        reportsOpt.ifPresent(MontiCoreReports::close);
+        // Clean up after groovy
+        try {
+          groovyClassLoader.close();
+        } catch (IOException ignored) {
         }
       }
     }


### PR DESCRIPTION
* Our favourite Java bug [JDK-8078641](https://bugs.openjdk.org/browse/JDK-8078641) in combination with groovy retains all loaded classes (via the classloader of the groovy script to the GC roots)
* "Solution": Invalidate a classloader delegatee  after the generator has run

The `DelegatingClassLoader ` is also a part of se-commons-groovy 7.8.0+ (and can be removed following the next release)