### PR TITLE
Update MontiVerseCI

### DIFF
--- a/.github/workflows/call_montiverse_branch.yml
+++ b/.github/workflows/call_montiverse_branch.yml
@@ -40,7 +40,8 @@ jobs:
         # Write the result into the steps summary
         # Fetch the related PRs (if applicable)
       - uses: octokit/request-action@v2.x
-        if: ${{ ! github.event.pull_request.number }}
+        name: 'Fetch related PR (if not already known)'
+        if: ${{ (success() || failure()) && !github.event.pull_request.number }}
         id: get_related_pr
         with:
           route: GET /repos/{ownerandrepo}/commits/{commit_sha}/pulls
@@ -50,7 +51,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Extract the PR-number
       - id: related_pr
-        if: ${{ ! github.event.pull_request.number }}
+        name: 'Extract related PR (if not already known)'
+        if: ${{ (success() || failure()) && !github.event.pull_request.number }}
         run: echo "number=${{ fromJson(steps.get_related_pr.outputs.data)[0].number }}" >> $GITHUB_OUTPUT
 
         # in case we can't find a PR => we only report via the job summary
@@ -58,7 +60,7 @@ jobs:
         # we could find a PR => Update the last message (or create a new one=
       - name: Find last Comment on PR
         uses: peter-evans/find-comment@v3
-        if: ${{ github.event.pull_request.number || steps.related_pr.outputs.number }}
+        if: ${{ (success() || failure()) && (github.event.pull_request.number || steps.related_pr.outputs.number) }}
         id: fc
         with:
           issue-number: ${{  github.event.pull_request.number || steps.related_pr.outputs.number }}
@@ -67,7 +69,7 @@ jobs:
 
       - name: Create or update PR comment
         uses: peter-evans/create-or-update-comment@v4
-        if: ${{  github.event.pull_request.number || steps.related_pr.outputs.number }}
+        if: ${{ (success() || failure()) && (github.event.pull_request.number || steps.related_pr.outputs.number) }}
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{  github.event.pull_request.number || steps.related_pr.outputs.number }}

--- a/.github/workflows/call_montiverse_branch.yml
+++ b/.github/workflows/call_montiverse_branch.yml
@@ -21,7 +21,6 @@ jobs:
   trigger-montiverse:
     runs-on: ubuntu-latest
     permissions:
-      contents: write       # to write commit comments
       pull-requests: write  # to write PR comments
     steps:
       - name: Extract Branch Name
@@ -38,8 +37,7 @@ jobs:
           id: '91803'  # MontiVerseCI project id
           ref: 'main'
           variables: '{"${{inputs.project}}_BRANCH":"${{env.BRANCH_NAME}}", "${{inputs.project}}_PROJECT":"${{ github.event.repository.full_name  }}"}'
-        # Next, we want to either reply on the PR with the status (or if no PR was found, add a comment to the commit)
-
+        # Write the result into the steps summary
         # Fetch the related PRs (if applicable)
       - uses: octokit/request-action@v2.x
         if: ${{ ! github.event.pull_request.number }}
@@ -55,12 +53,7 @@ jobs:
         if: ${{ ! github.event.pull_request.number }}
         run: echo "number=${{ fromJson(steps.get_related_pr.outputs.data)[0].number }}" >> $GITHUB_OUTPUT
 
-        # we could not find a PR => comment on the commit
-      - name: Reply on Commit
-        if: ${{ ! github.event.pull_request.number && !steps.related_pr.outputs.number }}
-        uses: peter-evans/commit-comment@v3
-        with:
-          body: "${{steps.montiverse.outputs.pretty_output}}\n\n(Could not find a related PR)"
+        # in case we can't find a PR => we only report via the job summary
 
         # we could find a PR => Update the last message (or create a new one=
       - name: Find last Comment on PR

--- a/.github/workflows/call_montiverse_branch.yml
+++ b/.github/workflows/call_montiverse_branch.yml
@@ -20,13 +20,17 @@ jobs:
   # The MontiVerse is a suite of projects, which are not build & tested with the given changes on a branch
   trigger-montiverse:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # to write commit comments
+      pull-requests: write  # to write PR comments
     steps:
       - name: Extract Branch Name
         # We have to remove the refs/heads/ prefix from the branch which called this action
         run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Trigger MontiVerse
         # Then actually trigger the MontiVerseCI projects pipeline
-        uses: digital-blueprint/gitlab-pipeline-trigger-action@c81ead300bf664f76245d816268c4a1b4bed2604 # @v1.2.0
+        uses: luepges/MontiVerseAction@main #
+        id: montiverse
         with:
           host: 'git.rwth-aachen.de'
           trigger_token: ${{ secrets.MONTIVERSE_TRIGGER_TOKEN }}
@@ -34,3 +38,45 @@ jobs:
           id: '91803'  # MontiVerseCI project id
           ref: 'main'
           variables: '{"${{inputs.project}}_BRANCH":"${{env.BRANCH_NAME}}", "${{inputs.project}}_PROJECT":"${{ github.event.repository.full_name  }}"}'
+        # Next, we want to either reply on the PR with the status (or if no PR was found, add a comment to the commit)
+
+        # Fetch the related PRs (if applicable)
+      - uses: octokit/request-action@v2.x
+        if: ${{ ! github.event.pull_request.number }}
+        id: get_related_pr
+        with:
+          route: GET /repos/{ownerandrepo}/commits/{commit_sha}/pulls
+          ownerandrepo: ${{ github.repository }}
+          commit_sha: ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Extract the PR-number
+      - id: related_pr
+        if: ${{ ! github.event.pull_request.number }}
+        run: echo "number=${{ fromJson(steps.get_related_pr.outputs.data)[0].number }}" >> $GITHUB_OUTPUT
+
+        # we could not find a PR => comment on the commit
+      - name: Reply on Commit
+        if: ${{ ! github.event.pull_request.number && !steps.related_pr.outputs.number }}
+        uses: peter-evans/commit-comment@v3
+        with:
+          body: "${{steps.montiverse.outputs.pretty_output}}\n\n(Could not find a related PR)"
+
+        # we could find a PR => Update the last message (or create a new one=
+      - name: Find last Comment on PR
+        uses: peter-evans/find-comment@v3
+        if: ${{ github.event.pull_request.number || steps.related_pr.outputs.number }}
+        id: fc
+        with:
+          issue-number: ${{  github.event.pull_request.number || steps.related_pr.outputs.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: MontiVerse Result
+
+      - name: Create or update PR comment
+        uses: peter-evans/create-or-update-comment@v4
+        if: ${{  github.event.pull_request.number || steps.related_pr.outputs.number }}
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{  github.event.pull_request.number || steps.related_pr.outputs.number }}
+          body: "${{steps.montiverse.outputs.pretty_output}}\n<!-- MontiVerse Result -->"
+          edit-mode: replace

--- a/.github/workflows/gradle_mc.yml
+++ b/.github/workflows/gradle_mc.yml
@@ -42,6 +42,7 @@ jobs:
         run: gradle build -p monticore-generator ${{env.GRADLE_CLI_OPTS}}
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
+        if: always() # always run even if the previous step fails
         with:
           report_paths: '**/target/test-results/test/TEST-*.xml'
 
@@ -59,6 +60,7 @@ jobs:
         run: gradle buildMC ${{env.GRADLE_CLI_OPTS}} -PgenTR=true -PgenEMF=true -PgenTagging=true
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
+        if: always() # always run even if the previous step fails
         with:
           report_paths: '**/target/test-results/test/TEST-*.xml'
 
@@ -77,6 +79,7 @@ jobs:
         run: gradle build test -p monticore-test/01.experiments ${{env.GRADLE_CLI_OPTS}} -PgenEMF=true
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
+        if: always() # always run even if the previous step fails
         with:
           report_paths: '**/target/test-results/test/TEST-*.xml'
 
@@ -95,6 +98,7 @@ jobs:
         run: gradle build test -p monticore-test/02.experiments ${{env.GRADLE_CLI_OPTS}} -PgenEMF=true
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
+        if: always() # always run even if the previous step fails
         with:
           report_paths: '**/target/test-results/test/TEST-*.xml'
 
@@ -115,6 +119,7 @@ jobs:
         run: if pgrep java | xargs -i ls -la /proc/{}/fd | grep "monticore-test/it/target/"; then echo "Found open file handles!"; exit 1; else echo "No open file handles."; exit 0; fi
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
+        if: always() # always run even if the previous step fails
         with:
           report_paths: '**/target/test-results/test/TEST-*.xml'
 
@@ -133,6 +138,7 @@ jobs:
         run: gradle build test -p monticore-test/it ${{env.GRADLE_CLI_OPTS}} -PbuildProfile=emf -PgenEMF=true
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
+        if: always() # always run even if the previous step fails
         with:
           report_paths: '**/target/test-results/test/TEST-*.xml'
 
@@ -151,6 +157,7 @@ jobs:
         run: gradle build test -p monticore-test/monticore-grammar-it ${{env.GRADLE_CLI_OPTS}} -PgenEMF=true
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
+        if: always() # always run even if the previous step fails
         with:
           report_paths: '**/target/test-results/test/TEST-*.xml'
 
@@ -169,6 +176,7 @@ jobs:
         run: gradle build test -p monticore-test/montitrans ${{env.GRADLE_CLI_OPTS}} -PgenTR=true
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
+        if: always() # always run even if the previous step fails
         with:
           report_paths: '**/target/test-results/test/TEST-*.xml'
 

--- a/.github/workflows/gradle_mc.yml
+++ b/.github/workflows/gradle_mc.yml
@@ -202,6 +202,8 @@ jobs:
     uses: ./.github/workflows/call_montiverse_branch.yml
     with:
       project: "MONTICORE"
+    permissions:  # allow this action to give feedback on its checks
+      pull-requests: write
     secrets: inherit
 
 

--- a/.github/workflows/gradle_mc.yml
+++ b/.github/workflows/gradle_mc.yml
@@ -27,29 +27,45 @@ permissions:
 
 
 jobs:
-  build-generator: # Note: Build-Cache may not work yet
+  build-generator:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name # do not run duplicate jobs on PRs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project sources
-        uses: actions/checkout@v3
-      - name: Build the monticore-generator
-        uses: gradle/actions/setup-gradle@v3
+        uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: ${{env.GRADLE_VERSION}}
-          arguments: build -p monticore-generator ${{env.GRADLE_CLI_OPTS}}
+      - name: Build the monticore-generator
+        run: gradle build -p monticore-generator ${{env.GRADLE_CLI_OPTS}}
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: junit-generator-tests-results
+          path: '**/target/test-results/test/TEST-*.xml'
+          retention-days: 1
 
   build-mc:
     runs-on: ubuntu-latest
     needs: build-generator
     steps:
       - name: Checkout project sources
-        uses: actions/checkout@v3
-      - name: Build monticore (buildMC)
-        uses: gradle/actions/setup-gradle@v3
+        uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: ${{env.GRADLE_VERSION}}
-          arguments: buildMC ${{env.GRADLE_CLI_OPTS}} -PgenTR=true -PgenEMF=true -PgenTagging=true
+      - name: Build monticore (buildMC)
+        run: gradle buildMC ${{env.GRADLE_CLI_OPTS}} -PgenTR=true -PgenEMF=true -PgenTagging=true
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: junit-mc-test-results
+          path: '**/target/test-results/test/TEST-*.xml'
+          retention-days: 1
 
   # first set of experiments from the handbook
   test-01-experiments:
@@ -57,12 +73,20 @@ jobs:
     needs: build-mc
     steps:
       - name: Checkout project sources
-        uses: actions/checkout@v3
-      - name: Test 01.experiments
-        uses: gradle/actions/setup-gradle@v3
+        uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: ${{env.GRADLE_VERSION}}
-          arguments: build test -p monticore-test/01.experiments ${{env.GRADLE_CLI_OPTS}} -PgenEMF=true
+      - name: Test 01.experiments
+        run: gradle build test -p monticore-test/01.experiments ${{env.GRADLE_CLI_OPTS}} -PgenEMF=true
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: junit-exp01-test-results
+          path: '**/target/test-results/test/TEST-*.xml'
+          retention-days: 1
 
   # second set of experiments from the handbook
   test-02-experiments:
@@ -70,12 +94,20 @@ jobs:
     needs: build-mc
     steps:
       - name: Checkout project sources
-        uses: actions/checkout@v3
-      - name: Test 02.experiments
-        uses: gradle/actions/setup-gradle@v3
+        uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: ${{env.GRADLE_VERSION}}
-          arguments: build test -p monticore-test/02.experiments ${{env.GRADLE_CLI_OPTS}} -PgenEMF=true
+      - name: Test 02.experiments
+        run: gradle build test -p monticore-test/02.experiments ${{env.GRADLE_CLI_OPTS}} -PgenEMF=true
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: junit-exp02-test-results
+          path: '**/target/test-results/test/TEST-*.xml'
+          retention-days: 1
 
   # test integration tests from the it project
   test-it:
@@ -83,27 +115,43 @@ jobs:
     needs: build-mc
     steps:
       - name: Checkout project sources
-        uses: actions/checkout@v3
-      - name: Test monticore-test/it
-        uses: gradle/actions/setup-gradle@v3
+        uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: ${{env.GRADLE_VERSION}}
-          arguments: build test -p monticore-test/it ${{env.GRADLE_CLI_OPTS}}
+      - name: Test monticore-test/it
+        run: gradle build test -p monticore-test/it ${{env.GRADLE_CLI_OPTS}}
       - name: Checking that all file handles in the target folder are closed
         run: if pgrep java | xargs -i ls -la /proc/{}/fd | grep "monticore-test/it/target/"; then echo "Found open file handles!"; exit 1; else echo "No open file handles."; exit 0; fi
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: junit-it-test-results
+          path: '**/target/test-results/test/TEST-*.xml'
+          retention-days: 1
 
-  # test integration tests from the it project, using the emf profile
+  # test integration tests from the "it" project, using the emf profile
   test-it-emf:
     runs-on: ubuntu-latest
     needs: build-mc
     steps:
       - name: Checkout project sources
-        uses: actions/checkout@v3
-      - name: Test monticore-test/it with emf profile
-        uses: gradle/actions/setup-gradle@v3
+        uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: ${{env.GRADLE_VERSION}}
-          arguments: build test -p monticore-test/it ${{env.GRADLE_CLI_OPTS}} -PbuildProfile=emf -PgenEMF=true
+      - name: Test monticore-test/it with emf profile
+        run: gradle build test -p monticore-test/it ${{env.GRADLE_CLI_OPTS}} -PbuildProfile=emf -PgenEMF=true
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: junit-it-emf-test-results
+          path: '**/target/test-results/test/TEST-*.xml'
+          retention-days: 1
 
   # Grammar integration tests
   test-grammar-it:
@@ -111,12 +159,20 @@ jobs:
     needs: build-mc
     steps:
       - name: Checkout project sources
-        uses: actions/checkout@v3
-      - name: Test monticore-grammar-it
-        uses: gradle/actions/setup-gradle@v3
+        uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: ${{env.GRADLE_VERSION}}
-          arguments: build test -p monticore-test/monticore-grammar-it ${{env.GRADLE_CLI_OPTS}} -PgenEMF=true
+      - name: Test monticore-grammar-it
+        run: gradle build test -p monticore-test/monticore-grammar-it ${{env.GRADLE_CLI_OPTS}} -PgenEMF=true
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: junit-grammar-it-test-results
+          path: '**/target/test-results/test/TEST-*.xml'
+          retention-days: 1
 
   # Transformation tests
   test-montitrans:
@@ -124,32 +180,30 @@ jobs:
     needs: build-mc
     steps:
       - name: Checkout project sources
-        uses: actions/checkout@v3
-      - name: Test monticore-grammar-it
-        uses: gradle/actions/setup-gradle@v3
+        uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: ${{env.GRADLE_VERSION}}
-          arguments: build test -p monticore-test/montitrans ${{env.GRADLE_CLI_OPTS}} -PgenTR=true
-
+      - name: Test monticore-grammar-it
+        run: gradle build test -p monticore-test/montitrans ${{env.GRADLE_CLI_OPTS}} -PgenTR=true
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: junit-tr-test-results
+          path: '**/target/test-results/test/TEST-*.xml'
+          retention-days: 1
 
 
   # Run the MontiVerse pipeline (tests this change on a suite of projects)
   trigger-montiverse:
     if: github.event_name == 'pull_request' # only run on PRs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger MontiVerse
-        uses: digital-blueprint/gitlab-pipeline-trigger-action@v1
-        with:
-          host: 'git.rwth-aachen.de'
-          trigger_token: ${{ secrets.MONTIVERSE_TRIGGER_TOKEN }}
-          access_token: ${{ secrets.MONTIVERSE_ACCESS_TOKEN }}  # Access is required to show the status
-          id: '91803'  # montiverseci project id
-          ref: 'main'
-          # TODO: Include entire git path here instead (due to PRs)
-          variables: '{"MONTICORE_BRANCH":"${{github.event.pull_request.head.ref }}", "MONTICORE_PROJECT":"${{ github.event.pull_request.head.repo.full_name }}"}'
+    uses: ./.github/workflows/call_montiverse_branch.yml
+    with:
+      project: "MONTICORE"
+    secrets: inherit
 
-        # TODO: Proper message in PRs (turn the MontiVerse into a GitHub Action?)?
 
 # TODO: FIX to specific version instead of @v3
 

--- a/.github/workflows/gradle_mc.yml
+++ b/.github/workflows/gradle_mc.yml
@@ -24,6 +24,7 @@ env:
 
 permissions:
   contents: read # This action may run somewhat unsafe code
+  checks: write
 
 
 jobs:
@@ -39,13 +40,10 @@ jobs:
           gradle-version: ${{env.GRADLE_VERSION}}
       - name: Build the monticore-generator
         run: gradle build -p monticore-generator ${{env.GRADLE_CLI_OPTS}}
-      - name: Upload Test Report
-        uses: actions/upload-artifact@v4
-        if: always() # always run even if the previous step fails
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
         with:
-          name: junit-generator-tests-results
-          path: '**/target/test-results/test/TEST-*.xml'
-          retention-days: 1
+          report_paths: '**/target/test-results/test/TEST-*.xml'
 
   build-mc:
     runs-on: ubuntu-latest
@@ -59,13 +57,10 @@ jobs:
           gradle-version: ${{env.GRADLE_VERSION}}
       - name: Build monticore (buildMC)
         run: gradle buildMC ${{env.GRADLE_CLI_OPTS}} -PgenTR=true -PgenEMF=true -PgenTagging=true
-      - name: Upload Test Report
-        uses: actions/upload-artifact@v4
-        if: always() # always run even if the previous step fails
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
         with:
-          name: junit-mc-test-results
-          path: '**/target/test-results/test/TEST-*.xml'
-          retention-days: 1
+          report_paths: '**/target/test-results/test/TEST-*.xml'
 
   # first set of experiments from the handbook
   test-01-experiments:
@@ -80,13 +75,10 @@ jobs:
           gradle-version: ${{env.GRADLE_VERSION}}
       - name: Test 01.experiments
         run: gradle build test -p monticore-test/01.experiments ${{env.GRADLE_CLI_OPTS}} -PgenEMF=true
-      - name: Upload Test Report
-        uses: actions/upload-artifact@v4
-        if: always() # always run even if the previous step fails
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
         with:
-          name: junit-exp01-test-results
-          path: '**/target/test-results/test/TEST-*.xml'
-          retention-days: 1
+          report_paths: '**/target/test-results/test/TEST-*.xml'
 
   # second set of experiments from the handbook
   test-02-experiments:
@@ -101,13 +93,10 @@ jobs:
           gradle-version: ${{env.GRADLE_VERSION}}
       - name: Test 02.experiments
         run: gradle build test -p monticore-test/02.experiments ${{env.GRADLE_CLI_OPTS}} -PgenEMF=true
-      - name: Upload Test Report
-        uses: actions/upload-artifact@v4
-        if: always() # always run even if the previous step fails
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
         with:
-          name: junit-exp02-test-results
-          path: '**/target/test-results/test/TEST-*.xml'
-          retention-days: 1
+          report_paths: '**/target/test-results/test/TEST-*.xml'
 
   # test integration tests from the it project
   test-it:
@@ -124,13 +113,10 @@ jobs:
         run: gradle build test -p monticore-test/it ${{env.GRADLE_CLI_OPTS}}
       - name: Checking that all file handles in the target folder are closed
         run: if pgrep java | xargs -i ls -la /proc/{}/fd | grep "monticore-test/it/target/"; then echo "Found open file handles!"; exit 1; else echo "No open file handles."; exit 0; fi
-      - name: Upload Test Report
-        uses: actions/upload-artifact@v4
-        if: always() # always run even if the previous step fails
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
         with:
-          name: junit-it-test-results
-          path: '**/target/test-results/test/TEST-*.xml'
-          retention-days: 1
+          report_paths: '**/target/test-results/test/TEST-*.xml'
 
   # test integration tests from the "it" project, using the emf profile
   test-it-emf:
@@ -145,13 +131,10 @@ jobs:
           gradle-version: ${{env.GRADLE_VERSION}}
       - name: Test monticore-test/it with emf profile
         run: gradle build test -p monticore-test/it ${{env.GRADLE_CLI_OPTS}} -PbuildProfile=emf -PgenEMF=true
-      - name: Upload Test Report
-        uses: actions/upload-artifact@v4
-        if: always() # always run even if the previous step fails
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
         with:
-          name: junit-it-emf-test-results
-          path: '**/target/test-results/test/TEST-*.xml'
-          retention-days: 1
+          report_paths: '**/target/test-results/test/TEST-*.xml'
 
   # Grammar integration tests
   test-grammar-it:
@@ -166,13 +149,10 @@ jobs:
           gradle-version: ${{env.GRADLE_VERSION}}
       - name: Test monticore-grammar-it
         run: gradle build test -p monticore-test/monticore-grammar-it ${{env.GRADLE_CLI_OPTS}} -PgenEMF=true
-      - name: Upload Test Report
-        uses: actions/upload-artifact@v4
-        if: always() # always run even if the previous step fails
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
         with:
-          name: junit-grammar-it-test-results
-          path: '**/target/test-results/test/TEST-*.xml'
-          retention-days: 1
+          report_paths: '**/target/test-results/test/TEST-*.xml'
 
   # Transformation tests
   test-montitrans:
@@ -187,14 +167,10 @@ jobs:
           gradle-version: ${{env.GRADLE_VERSION}}
       - name: Test monticore-grammar-it
         run: gradle build test -p monticore-test/montitrans ${{env.GRADLE_CLI_OPTS}} -PgenTR=true
-      - name: Upload Test Report
-        uses: actions/upload-artifact@v4
-        if: always() # always run even if the previous step fails
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
         with:
-          name: junit-tr-test-results
-          path: '**/target/test-results/test/TEST-*.xml'
-          retention-days: 1
-
+          report_paths: '**/target/test-results/test/TEST-*.xml'
 
   # Run the MontiVerse pipeline (tests this change on a suite of projects)
   trigger-montiverse:

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,6 @@ subprojects {
       }
     }
     reports {
-      junitXml.required = false
       html.required = false
     }
   }

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -27,14 +27,14 @@ In addition, the tutorial tar.gz is packaged and added as an artifact (TODO).
 
 # Secrets
 
-| Name                     | Description                                                                                                                     | Workflows                             |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
-| SE_NEXUS_USER            |                                                                                                                                 | deploy_snapshot_mc, deploy_release_mc |
-| SE_NEXUS_PASSWORD        |                                                                                                                                 | deploy_snapshot_mc, deploy_release_mc |
-| DOWNSTREAM_PAT           | Personal access token to trigger downstream projects on GitHub (fine grained: content: write, actions: write)                   | deploy_snapshot_mc                    |
-| DOWNSTREAM_GITLAB_PAT    | Personal access token to trigger downstream projects on GitLab (not required for now)                                           | deploy_snapshot_mc                    |
-| GITLAB_TOKEN             | Checks out the monticore-pygments-highlighting project from GitLab                                                              | prepare_pages                         |
-| MONTIVERSE_TRIGGER_TOKEN | Triggers the MontiVerse IT-Pipeline on GitLab [more](https://github.com/digital-blueprint/gitlab-pipeline-trigger-action)       | gradle_mc                             |
-| MONTIVERSE_ACCESS_TOKEN  | Reads the MontiVerse IT-Pipeline status from GitLab [more](https://github.com/digital-blueprint/gitlab-pipeline-trigger-action) | gradle_mc                             |
+| Name                     | Description                                                                                                                                                                                                                            | Workflows                             |
+|--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
+| SE_NEXUS_USER            |                                                                                                                                                                                                                                        | deploy_snapshot_mc, deploy_release_mc |
+| SE_NEXUS_PASSWORD        |                                                                                                                                                                                                                                        | deploy_snapshot_mc, deploy_release_mc |
+| DOWNSTREAM_PAT           | Personal access token to trigger downstream projects on GitHub (fine grained: content: write, actions: write)                                                                                                                          | deploy_snapshot_mc                    |
+| DOWNSTREAM_GITLAB_PAT    | Personal access token to trigger downstream projects on GitLab (not required for now)                                                                                                                                                  | deploy_snapshot_mc                    |
+| GITLAB_TOKEN             | Checks out the monticore-pygments-highlighting project from GitLab                                                                                                                                                                     | prepare_pages                         |
+| MONTIVERSE_TRIGGER_TOKEN | Triggers the MontiVerse IT-Pipeline on GitLab [more](https://github.com/digital-blueprint/gitlab-pipeline-trigger-action)                                                                                                              | gradle_mc                             |
+| MONTIVERSE_ACCESS_TOKEN  | Reads the MontiVerse IT-Pipeline status from GitLab [more](https://github.com/digital-blueprint/gitlab-pipeline-trigger-action), must have access to [montiverseciprojects](https://git.rwth-aachen.de/monticore/montiverseciprojects) | gradle_mc                             |
 
 

--- a/monticore-generator/build.gradle
+++ b/monticore-generator/build.gradle
@@ -112,7 +112,6 @@ tasks.withType(Test) {
         }
     }
     reports {
-        junitXml.required = false
         html.required = false
     }
 }


### PR DESCRIPTION
* Use MontiVerse GitHub Action
  * Increased verbosity 
* Re-use the montiverse workflow definition
* Upload JUnit Reports (for normal builds)

The `permissions.pull-requests: write` has to be added to the downstream projects' montiverse jobs 