### PR TITLE
Always report the decorated CD

### DIFF
--- a/monticore-generator/src/main/resources/de/monticore/monticore_emf.groovy
+++ b/monticore-generator/src/main/resources/de/monticore/monticore_emf.groovy
@@ -91,6 +91,8 @@ while (grammarIterator.hasNext()) {
       decorateWithInterpreter(cd, decoratedCD, glex)
     }
 
+    reportDecoratedCD(decoratedCD, report)
+
     // groovy script hook point
     hook(gh2, glex, astGrammar, decoratedCD, cd)
 

--- a/monticore-generator/src/main/resources/de/monticore/monticore_noreports.groovy
+++ b/monticore-generator/src/main/resources/de/monticore/monticore_noreports.groovy
@@ -92,6 +92,8 @@ while (grammarIterator.hasNext()) {
       decorateWithInterpreter(cd, decoratedCD, glex)
     }
 
+    reportDecoratedCD(decoratedCD, report)
+
     // groovy script hook point
     hook(gh2, glex, astGrammar, decoratedCD, cd)
 


### PR DESCRIPTION
* The initial CD is reported earlier in the workflow (`reportCD`), so we should also report the decorated file