### PR TITLE
Add source node info to CompKindExpression

### DIFF
--- a/monticore-grammar/src/main/java/de/monticore/types/check/CompKindExpression.java
+++ b/monticore-grammar/src/main/java/de/monticore/types/check/CompKindExpression.java
@@ -103,6 +103,10 @@ public abstract class CompKindExpression {
 
   /**
    * The ast node on which this CompKindExpression is based, if present.
+   * <p>
+   * This is ONLY meant to be used to create better log messages!
+   * As CompKindExpressions are moved around, cloned, and modified, it cannot be
+   * assumed that the reference to the AST node holds reliable.
    */
   public Optional<ASTNode> getSourceNode() {
     return this.sourceNode;

--- a/monticore-grammar/src/main/java/de/monticore/types/check/CompKindExpression.java
+++ b/monticore-grammar/src/main/java/de/monticore/types/check/CompKindExpression.java
@@ -2,6 +2,7 @@
 package de.monticore.types.check;
 
 import com.google.common.base.Preconditions;
+import de.monticore.ast.ASTNode;
 import de.monticore.expressions.assignmentexpressions._ast.ASTAssignmentExpression;
 import de.monticore.expressions.expressionsbasis._ast.ASTExpression;
 import de.monticore.expressions.expressionsbasis._ast.ASTNameExpression;
@@ -25,6 +26,7 @@ public abstract class CompKindExpression {
   protected final ComponentSymbol component;
   protected LinkedHashMap<VariableSymbol, ASTExpression> parameterBindings;
   protected List<ASTExpression> arguments;
+  protected Optional<ASTNode> sourceNode;
 
   /**
    * @return a {@code List} of the configuration arguments of this component.
@@ -98,6 +100,28 @@ public abstract class CompKindExpression {
 
     this.parameterBindings = parameterBindings;
   }
+
+  /**
+   * The ast node on which this CompKindExpression is based, if present.
+   */
+  public Optional<ASTNode> getSourceNode() {
+    return this.sourceNode;
+  }
+
+  /**
+   * @see CompKindExpression#getSourceNode
+   * @param sourceNode Must not be null
+   */
+  public void setSourceNode(ASTNode sourceNode) {
+    Preconditions.checkNotNull(sourceNode);
+    this.sourceNode = Optional.of(sourceNode);
+  }
+
+  /** @see CompKindExpression#getSourceNode */
+  public void setSourceNodeAbsent() {
+    this.sourceNode = Optional.empty();
+  }
+
   protected CompKindExpression(ComponentSymbol component) {
     Preconditions.checkNotNull(component);
     this.component = component;


### PR DESCRIPTION
This will better support correct error position printing in cocos that have to do with component type checking. MontiCore provides a similar attribute for `SymTypeExpressions` via [`.getSourceInfo()`](https://github.com/MontiCore/monticore/blob/3aacee8a3791dbef6a2e14a2b7aab64424682629/monticore-grammar/src/main/java/de/monticore/types/check/SymTypeExpression.java#L691-L693). The returned object of type `SymTypeSourceInfo` has a field [`sourceNode`](https://github.com/MontiCore/monticore/blob/dev/monticore-grammar/src/main/java/de/monticore/types/check/SymTypeSourceInfo.java#L20-L24) with [associated method](https://github.com/MontiCore/monticore/blob/dev/monticore-grammar/src/main/java/de/monticore/types/check/SymTypeSourceInfo.java#L59-L72) by which we obtain the ast node on which the type expression is based, if present. 

A direct use case for having such an attribute for `CompKindExpression`s is MontiArc's type checking of generic component type arguments. E.g., the symbol table creation adds `CompKindExpression`s for declared parent components to the symbol of a component type. When we check the correct type binding of the type parameters, the entry point for the coco is the component type ast from which we obtain the component type symbol. From there on, we check all parent `CompKindExpression`s. However, there is no direct connection between the `CompKindExpression` and the ast node, in which the parent extension was declared. Thus it is hard to infer this location. The `sourceNode` attribute would help here.