### PR TITLE
Init source node of CompKindExpressions with empty optional

### DIFF
--- a/monticore-grammar/src/main/java/de/monticore/types/check/CompKindExpression.java
+++ b/monticore-grammar/src/main/java/de/monticore/types/check/CompKindExpression.java
@@ -131,6 +131,7 @@ public abstract class CompKindExpression {
     this.component = component;
     this.arguments = new ArrayList<>();
     this.parameterBindings = new LinkedHashMap<>();
+    this.sourceNode = Optional.empty();
   }
 
   public ComponentSymbol getTypeInfo() {


### PR DESCRIPTION
So that if `CompKindExpression#getSourceNode` is called without explicitly setting a source node or explicitly setting it absent does not return null. 