### PR TITLE
Init CompKind  source node

### DIFF
--- a/monticore-grammar/src/main/java/de/monticore/types/check/CompKindExpression.java
+++ b/monticore-grammar/src/main/java/de/monticore/types/check/CompKindExpression.java
@@ -131,6 +131,7 @@ public abstract class CompKindExpression {
     this.component = component;
     this.arguments = new ArrayList<>();
     this.parameterBindings = new LinkedHashMap<>();
+    this.sourceNode = Optional.empty();
   }
 
   public ComponentSymbol getTypeInfo() {

--- a/monticore-grammar/src/main/java/de/monticore/types/check/SynthesizeCompTypeFromMCBasicTypes.java
+++ b/monticore-grammar/src/main/java/de/monticore/types/check/SynthesizeCompTypeFromMCBasicTypes.java
@@ -54,17 +54,20 @@ public class SynthesizeCompTypeFromMCBasicTypes implements MCBasicTypesHandler {
         node.get_SourcePositionStart(), node.get_SourcePositionEnd()
       );
       this.resultWrapper.setResultAbsent();
-    } else if (comp.size() > 1) {
-      Log.error(
-          String.format(
-              "0xD0105 Ambiguous reference, both '%s' and '%s' match'",
-              comp.get(0).getFullName(), comp.get(1).getFullName()
-          ),
-        node.get_SourcePositionStart(), node.get_SourcePositionEnd()
-      );
-      this.resultWrapper.setResult(new KindOfComponent(comp.get(0)));
     } else {
-      this.resultWrapper.setResult(new KindOfComponent(comp.get(0)));
+      CompKindExpression result = new KindOfComponent(comp.get(0));
+      result.setSourceNode(node);
+      this.resultWrapper.setResult(result);
+
+      if (comp.size() > 1) {
+        Log.error(
+          String.format(
+            "0xD0105 Ambiguous reference, both '%s' and '%s' match'",
+            comp.get(0).getFullName(), comp.get(1).getFullName()
+          ),
+          node.get_SourcePositionStart(), node.get_SourcePositionEnd()
+        );
+      }
     }
   }
 }

--- a/monticore-grammar/src/main/java/de/monticore/types/check/SynthesizeCompTypeFromMCSimpleGenericTypes.java
+++ b/monticore-grammar/src/main/java/de/monticore/types/check/SynthesizeCompTypeFromMCSimpleGenericTypes.java
@@ -76,7 +76,10 @@ public class SynthesizeCompTypeFromMCSimpleGenericTypes implements MCSimpleGener
           return typeResult != null && typeResult.isPresentResult() ? typeResult.getResult() : null;
         })
         .collect(Collectors.toList());
-      this.resultWrapper.setResult(new KindOfGenericComponent(compSym.get(0), typeArgExpressions));
+
+      CompKindExpression result = new KindOfGenericComponent(compSym.get(0), typeArgExpressions);
+      result.setSourceNode(mcType);
+      this.resultWrapper.setResult(result);
     }
   }
 


### PR DESCRIPTION
This merge request contains two aspects:
1. Set the `CompKindExpression#sourceNode` attribute by default to an empty optional, so that calling CompKindExpression#getSourceNode can never return `null` (this was missed out in #124 
2. `SynthesizeCompTypeFrom*` sets the `sourceNode` atttribute during the synthesis of CompKindExpressions