### PR TITLE
Fix component symbol port shadowing

### DIFF
--- a/monticore-grammar/src/main/java/de/monticore/symbols/compsymbols/_symboltable/ComponentSymbol.java
+++ b/monticore-grammar/src/main/java/de/monticore/symbols/compsymbols/_symboltable/ComponentSymbol.java
@@ -197,12 +197,14 @@ public class ComponentSymbol extends ComponentSymbolTOP {
     Set<PortSymbol> result = new LinkedHashSet<>(this.getPorts());
     for (CompKindExpression superComponent : this.getSuperComponentsList()) {
       if (visited.contains(superComponent.getTypeInfo())) continue;
+      Set<PortSymbol> inheritedPorts = new LinkedHashSet<>();
       for (PortSymbol port : superComponent.getTypeInfo().getAllPorts(visited)) {
         // Shadow super ports
         if (result.stream().noneMatch(e -> e.getName().equals(port.getName()))) {
-          result.add(port);
+          inheritedPorts.add(port);
         }
       }
+      result.addAll(inheritedPorts);
     }
     return result;
   }

--- a/monticore-grammar/src/test/java/de/monticore/symbols/compsymbols/_symboltable/ComponentSymbolTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/symbols/compsymbols/_symboltable/ComponentSymbolTest.java
@@ -1,0 +1,46 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.symbols.compsymbols._symboltable;
+
+
+import de.monticore.symbols.compsymbols.CompSymbolsMill;
+import de.monticore.types.check.KindOfComponent;
+import de.monticore.types.check.SymTypeExpressionFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Holds tests for the handwritten methods of {@link ComponentSymbol}.
+ */
+public class ComponentSymbolTest {
+
+  @Test
+  void shouldGetAllInheritedPortsWithOverlappingName() {
+    // Given
+    ComponentSymbol parent = CompSymbolsMill.componentSymbolBuilder()
+      .setSpannedScope(CompSymbolsMill.scope())
+      .setName("sut")
+      .build();
+
+    PortSymbol p1 = CompSymbolsMill.portSymbolBuilder().setName("p").setType(SymTypeExpressionFactory.createObscureType()).build();
+    PortSymbol p2 = CompSymbolsMill.portSymbolBuilder().setName("p").setType(SymTypeExpressionFactory.createObscureType()).build();
+
+    parent.getSpannedScope().add(p1);
+    parent.getSpannedScope().add(p2);
+
+    ComponentSymbol sut = CompSymbolsMill.componentSymbolBuilder()
+      .setName("sut")
+      .setSpannedScope(CompSymbolsMill.scope())
+      .setSuperComponentsList(Collections.singletonList(new KindOfComponent(parent)))
+      .build();
+
+    // When
+    Set<PortSymbol> ports = sut.getAllPorts();
+
+    // Then
+    Assertions.assertIterableEquals(List.of(p1, p2), ports);
+  }
+}


### PR DESCRIPTION
The `getAllPorts` method was too strict with its shadowing and removed inherited ports that shared the same name.