### PR TITLE
Fix spaces in FileReaderWriter

### DIFF
--- a/monticore-generator/src/main/java/de/monticore/MontiCoreScript.java
+++ b/monticore-generator/src/main/java/de/monticore/MontiCoreScript.java
@@ -112,6 +112,7 @@ import de.monticore.grammar.grammar_withconcepts._cocos.Grammar_WithConceptsCoCo
 import de.monticore.grammar.grammar_withconcepts._symboltable.Grammar_WithConceptsPhasedSTC;
 import de.monticore.grammar.grammar_withconcepts._symboltable.IGrammar_WithConceptsGlobalScope;
 import de.monticore.io.FileReaderWriter;
+import de.monticore.io.FileReaderWriterFix;
 import de.monticore.io.paths.MCPath;
 import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
 import de.monticore.symbols.basicsymbols._symboltable.DiagramSymbol;
@@ -1469,7 +1470,8 @@ public class MontiCoreScript extends Script implements GroovyRunner {
      */
     @Override
     protected void doRun(String script, Configuration configuration) {
-      FileReaderWriter.init();
+      //FileReaderWriter.init(); remove fix once 7.8.0 released
+      FileReaderWriterFix.init();
 
       GroovyInterpreter.Builder builder = GroovyInterpreter.newInterpreter()
               .withScriptBaseClass(MontiCoreScript.class)

--- a/monticore-generator/src/main/java/de/monticore/cli/MontiCoreTool.java
+++ b/monticore-generator/src/main/java/de/monticore/cli/MontiCoreTool.java
@@ -13,6 +13,7 @@ import de.monticore.StatisticsHandlerFix;
 import de.monticore.cli.updateChecker.UpdateCheckerRunnable;
 import de.monticore.generating.templateengine.reporting.Reporting;
 import de.monticore.grammar.grammar_withconcepts.Grammar_WithConceptsMill;
+import de.monticore.io.FileReaderWriterFix;
 import de.se_rwth.commons.logging.Log;
 import de.se_rwth.commons.logging.Slf4jLog;
 import org.apache.commons.cli.*;
@@ -91,6 +92,7 @@ public class MontiCoreTool {
    * @param args The input parameters for configuring the MontiCore tool.
    */
   public void run(String[] args) {
+    FileReaderWriterFix.init();
 
     runUpdateCheck();
   

--- a/monticore-generator/src/main/java/de/monticore/cli/MontiCoreTool.java
+++ b/monticore-generator/src/main/java/de/monticore/cli/MontiCoreTool.java
@@ -92,8 +92,6 @@ public class MontiCoreTool {
    * @param args The input parameters for configuring the MontiCore tool.
    */
   public void run(String[] args) {
-    FileReaderWriterFix.init();
-
     runUpdateCheck();
   
     Options options = initOptions();

--- a/monticore-generator/src/main/java/de/monticore/io/FileReaderWriterFix.java
+++ b/monticore-generator/src/main/java/de/monticore/io/FileReaderWriterFix.java
@@ -1,0 +1,56 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.io;
+
+import com.google.common.base.Charsets;
+import de.monticore.generating.templateengine.reporting.Reporting;
+import de.se_rwth.commons.io.SharedCloseable;
+import de.se_rwth.commons.logging.Log;
+
+import java.io.*;
+import java.net.JarURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+/**
+ * Fix introduced in MC 7.8.0-SNAPSHOT
+ */
+public class FileReaderWriterFix extends FileReaderWriter {
+  protected Reader _getReader(URL location) {
+    try {
+      if (!"jar".equals(location.getProtocol())) {
+        Path p = Paths.get(location.toURI());
+        Reporting.reportOpenInputFile(Optional.of(p.getParent()),
+                                      p.getParent().relativize(p));
+        // Do not try to decode URL
+        return new FileReader(new File(location.toURI()));
+      }
+      String[] parts = location.toURI().toString().split("!");
+      Path p = Paths.get(parts[1].substring(1));
+      Reporting.reportOpenInputFile(Optional.of(Paths.get(parts[0].substring(10))),
+                                    p);
+
+      // Save opened jar files for later cleanup
+      URLConnection conn = location.openConnection();
+      if (conn instanceof JarURLConnection) {
+        synchronized (SharedCloseable.class) {
+          // We have to ensure the JarURLConnection#getJarFile and new SharedCloseable are performed atomic.
+          // Otherwise, the backing JarFile might be closed in between.
+          // Note: the JVM shares JarFiles across classloader isolations
+          openedJarFiles.add(new SharedCloseable<>(((JarURLConnection) conn).getJarFile()));
+        }
+      }
+      return new InputStreamReader(conn.getInputStream(), Charsets.UTF_8.name());
+    } catch (IOException | URISyntaxException e) {
+      Log.error("0xA6104 Exception occurred while reading the file at '" + location + "':", e);
+    }
+    return null;
+  }
+
+  public static void init() {
+    INSTANCE = new FileReaderWriterFix();
+  }
+}

--- a/monticore-runtime/src/main/java/de/monticore/io/FileReaderWriter.java
+++ b/monticore-runtime/src/main/java/de/monticore/io/FileReaderWriter.java
@@ -247,11 +247,8 @@ public class FileReaderWriter {
         Path p = Paths.get(location.toURI());
         Reporting.reportOpenInputFile(Optional.of(p.getParent()),
           p.getParent().relativize(p));
-        if (location.getFile().charAt(2) == ':') {
-          String filename = URLDecoder.decode(location.getFile(), "UTF-8");
-          return new FileReader(filename.substring(1));
-        }
-        return new FileReader(location.getFile());
+        // Note: URL#getFile() might be unexpectedly encoded
+        return new FileReader(new File(location.toURI()));
       }
       String[] parts = location.toURI().toString().split("!");
       Path p = Paths.get(parts[1].substring(1));

--- a/monticore-runtime/src/main/java/de/monticore/io/paths/MCPath.java
+++ b/monticore-runtime/src/main/java/de/monticore/io/paths/MCPath.java
@@ -227,15 +227,22 @@ public final class MCPath {
     List<URL> resolvedURLs = findResolvedUrls(fixedPath);
 
     if (1 == resolvedURLs.size()) {
-      File resolvedFile = new File(resolvedURLs.get(0).getFile());
-      File parentFile = new File(resolvedFile.getParent());
-      if (parentFile.isDirectory()) {
-        String simpleName = new File(resolvedURLs.get(0).getFile()).getName();
-        if (Arrays.stream(parentFile.listFiles()).anyMatch(f -> simpleName.equals(f.getName()))) {
+      try {
+        // Note: URL#getFile() might be unexpectedly encoded
+        File resolvedFile = new File(resolvedURLs.get(0).toURI());
+        File parentFile = new File(resolvedFile.getParent());
+        if (parentFile.isDirectory()) {
+          // Special handling to ensure the file name matches without ignoring the case
+          String simpleName = new File(resolvedURLs.get(0).getFile()).getName();
+          if (Arrays.stream(parentFile.listFiles()).anyMatch(f -> simpleName.equals(f.getName()))) {
+            return Optional.of(resolvedURLs.get(0));
+          }
+        } else {
           return Optional.of(resolvedURLs.get(0));
         }
-      } else {
-        return Optional.of(resolvedURLs.get(0));
+      } catch (URISyntaxException e) {
+        Log.error("0xFDAB1: Unexpected uri format " + e.getMessage());
+        throw new RuntimeException(e);
       }
     }
     else if (1 < resolvedURLs.size()) {

--- a/monticore-runtime/src/main/java/de/monticore/io/paths/MCPath.java
+++ b/monticore-runtime/src/main/java/de/monticore/io/paths/MCPath.java
@@ -229,7 +229,13 @@ public final class MCPath {
     if (1 == resolvedURLs.size()) {
       try {
         // Note: URL#getFile() might be unexpectedly encoded
-        File resolvedFile = new File(resolvedURLs.get(0).toURI());
+        URI resolvedURI = resolvedURLs.get(0).toURI();
+        if (resolvedURI.isOpaque() || !resolvedURI.isAbsolute()) {
+          // For example, a jar:file:/home/.../MyFile.jar!/de/mc/Entry.mc4
+          // As the "parentFile" would be within the jar-filesystem, we do not do the check case-sensitive check
+          return Optional.of(resolvedURLs.get(0));
+        }
+        File resolvedFile = new File(resolvedURI);
         File parentFile = new File(resolvedFile.getParent());
         if (parentFile.isDirectory()) {
           // Special handling to ensure the file name matches without ignoring the case


### PR DESCRIPTION
* Paths such as `/tmp/hello world/` result in errors, that the file `/tmp/hello%20world/...` file does not exists
* Contains a backport of the fix

Due to the nature of file systems, testing this is difficult. 