### PR TITLE
Fix escaping of quotation symbols ' and " in implicit tokens.

### DIFF
--- a/monticore-generator/src/main/java/de/monticore/codegen/parser/ParserGeneratorHelper.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/parser/ParserGeneratorHelper.java
@@ -159,15 +159,22 @@ public class ParserGeneratorHelper {
     }
   }
 
+  /**
+   * @param str - A String whose contents were taken directly from a StringLiteral.
+   * @return The original string, but each occurrence of ' is replaced with \'.
+   */
+  @SuppressWarnings("unused") // Used in parser/Lexer.ftl
   public String escapeSingleQuote(String str) {
-    String retStr = "";
-    String del = "";
-    for (String s: str.split("'")) {
-      retStr += del;
-      retStr += s;
-      del = "\\'";
-    }
-    return retStr;
+    return str.replace("'", "\\'");
+  }
+
+  /**
+   * @param str - A String whose contents were taken directly from a StringLiteral.
+   * @return The original string, but each occurrence of \" is replaced by ".
+   */
+  @SuppressWarnings("unused") // Used in parser/Lexer.ftl
+  public String unescapeDoubleQuote(String str) {
+    return str.replace("\\\"", "\"");
   }
 
   /**

--- a/monticore-generator/src/main/resources/parser/Lexer.ftl
+++ b/monticore-generator/src/main/resources/parser/Lexer.ftl
@@ -13,7 +13,7 @@ ${tc.includeArgs("parser.LexerMember", [antlrGenerator, parserHelper.getGrammarS
 
 // Implicit token
 <#list genHelper.getLexSymbolsWithInherited() as lexSymbol>
-  ${genHelper.getOrComputeLexSymbolName(lexSymbol)} : '${genHelper.escapeSingleQuote(lexSymbol)}';
+  ${genHelper.getOrComputeLexSymbolName(lexSymbol)} : '${genHelper.unescapeDoubleQuote(genHelper.escapeSingleQuote(lexSymbol))}';
 </#list>
 
 // Explicit token

--- a/monticore-test/02.experiments/parser/src/main/grammars/QuoteTest.mc4
+++ b/monticore-test/02.experiments/parser/src/main/grammars/QuoteTest.mc4
@@ -1,0 +1,12 @@
+/* (c) https://github.com/MontiCore/monticore */
+
+/**
+ * This grammar is used to test that single quotes ' and double quotes " can be used in implicit tokens.
+ */
+grammar QuoteTest extends de.monticore.MCBasics {
+
+  EscapedNameSingleQuote = "n'" Name "'";
+  
+  EscapedNameDoubleQuote = "n\"" Name "\"";
+
+}

--- a/monticore-test/02.experiments/parser/src/test/java/QuoteTest.java
+++ b/monticore-test/02.experiments/parser/src/test/java/QuoteTest.java
@@ -1,0 +1,64 @@
+import de.se_rwth.commons.logging.Log;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import quotetest.QuoteTestMill;
+import quotetest._ast.ASTEscapedNameDoubleQuote;
+import quotetest._ast.ASTEscapedNameSingleQuote;
+import quotetest._parser.QuoteTestParser;
+
+import java.util.Optional;
+
+public class QuoteTest {
+    QuoteTestParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        QuoteTestMill.init();
+        parser = QuoteTestMill.parser();
+        Log.enableFailQuick(false);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        QuoteTestMill.reset();
+        Log.clearFindings();
+    }
+
+    @Test
+    public void testSingleQuoteValid() {
+        ASTEscapedNameSingleQuote ast = Assertions.assertDoesNotThrow(() -> parser.parse_StringEscapedNameSingleQuote(
+                "n'thisWorks'"
+        ).orElseThrow());
+        Assertions.assertEquals("thisWorks", ast.getName());
+        Assertions.assertEquals(0, Log.getFindingsCount());
+    }
+
+    @Test
+    public void testSingleQuoteInvalid() {
+        Optional<ASTEscapedNameSingleQuote> ast = Assertions.assertDoesNotThrow(() -> parser.parse_StringEscapedNameSingleQuote(
+                "nthisDoesNotWork"
+        ));
+        Assertions.assertFalse(ast.isPresent());
+        Assertions.assertTrue(Log.getFindingsCount() > 0);
+    }
+
+    @Test
+    public void testDoubleQuoteValid() {
+        ASTEscapedNameDoubleQuote ast = Assertions.assertDoesNotThrow(() -> parser.parse_StringEscapedNameDoubleQuote(
+                "n\"thisWorks\""
+        ).orElseThrow());
+        Assertions.assertEquals("thisWorks", ast.getName());
+        Assertions.assertEquals(0, Log.getFindingsCount());
+    }
+
+    @Test
+    public void testDoubleQuoteInvalid() {
+        Optional<ASTEscapedNameDoubleQuote> ast = Assertions.assertDoesNotThrow(() -> parser.parse_StringEscapedNameDoubleQuote(
+                "n\\\"thisDoesNotWork\\\""
+        ));
+        Assertions.assertFalse(ast.isPresent());
+        Assertions.assertTrue(Log.getFindingsCount() > 0);
+    }
+}


### PR DESCRIPTION
This fixes two similar bugs concerning single and double quotes in implicit tokens respectively.

The first bug occurs, when a single quote `'` is used as the last character in an implicit token.
Example:
```
ExampleProd = "d'";
```

Here, the generated Antlr token will be `'d'`, thus missing the single quote at the end. The expected behavior is that the single quote is escaped correctly, so in the example we expect `'d\''`.

The second bug occurs, whenever a double quote `"` is used in an implicit token.
Example:
```
ExampleProd2 = "d\"";
```

Here, the generated Antlr token will be `'d\"'`. This causes Antlr to throw an error, as escaping double quotes (`\"`) is not allowed in single quoted string literals. The expected behavior is that each occurrence of `\"` is replaced by `"` so in this example we expect the result `'d"'`.