### PR TITLE
Fix: Builder for Terminals present in the AST

### DIFF
--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/AbstractService.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/AbstractService.java
@@ -29,6 +29,7 @@ import de.monticore.umlmodifier._ast.ASTModifier;
 import de.monticore.umlstereotype._ast.ASTStereoValue;
 import de.se_rwth.commons.Joiners;
 import de.se_rwth.commons.Names;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 import javax.annotation.Nonnull;
 import java.util.*;
@@ -269,9 +270,23 @@ public class AbstractService<T extends AbstractService> {
       modifier.getStereotype().getValuesList().stream()
           .filter(value -> value.getName().equals(stereotype.toString()))
           .filter(ASTStereoValue::isPresentText)
-          .forEach(value -> values.add(value.getValue()));
+          .forEach(value -> values.add(getStereoValueValueFix(value))); // TODO: Replace with value.getValue() after 7.8.0-RELEASE
     }
     return values;
+  }
+
+  // TODO: Remove me after 7.8.0-RELEASE
+  protected String getStereoValueValueFix(ASTStereoValue stereoValue) {
+    // The ASTStereoValue#getValue() fails with strings
+    if (stereoValue.getContent() == null) {
+      if (stereoValue.isPresentText()) {
+        stereoValue.setContent(StringEscapeUtils.unescapeJava(stereoValue.getText().getValue()));
+      } else {
+        stereoValue.setContent("");
+      }
+    }
+
+    return stereoValue.getContent();
   }
 
   /**
@@ -313,6 +328,11 @@ public class AbstractService<T extends AbstractService> {
   public String getInheritedGrammarName(ASTCDAttribute attribute) {
     return getStereotypeValues(attribute.getModifier(), MC2CDStereotypes.INHERITED).get(0);
   }
+
+  public List<String> getTerminalDefaultValues(ASTCDAttribute attribute) {
+    return getStereotypeValues(attribute.getModifier(), MC2CDStereotypes.TERMINAL_DEFAULT_VALUE);
+  }
+
 
   public boolean hasDeprecatedStereotype(ASTModifier modifier) {
     return hasStereotype(modifier, MC2CDStereotypes.DEPRECATED);

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_ast/builder/BuilderDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_ast/builder/BuilderDecorator.java
@@ -13,12 +13,14 @@ import de.monticore.codegen.cd2java._ast.builder.buildermethods.BuilderMutatorMe
 import de.monticore.codegen.cd2java._ast.builder.inheritedmethods.InheritedBuilderMutatorMethodDecorator;
 import de.monticore.codegen.cd2java.exception.DecorateException;
 import de.monticore.codegen.cd2java.methods.AccessorDecorator;
+import de.monticore.codegen.mc2cd.MC2CDStereotypes;
 import de.monticore.generating.templateengine.GlobalExtensionManagement;
 import de.monticore.generating.templateengine.StringHookPoint;
 import de.monticore.generating.templateengine.TemplateHookPoint;
 import de.monticore.types.mcbasictypes._ast.ASTMCPrimitiveType;
 import de.monticore.types.mcbasictypes._ast.ASTMCType;
 import de.monticore.umlmodifier._ast.ASTModifier;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -136,6 +138,12 @@ public class BuilderDecorator extends AbstractCreator<ASTCDClass, ASTCDClass> {
 
     } else if (getDecorationHelper().isOptional(CD4CodeMill.prettyPrint(attribute.getMCType(), false))) {
       this.replaceTemplate(VALUE, attribute, new StringHookPoint("= Optional.empty()"));
+    } else if (service.hasStereotype(attribute.getModifier(), MC2CDStereotypes.TERMINAL_DEFAULT_VALUE)) {
+      // This terminal has a default value -> use it for the builder
+      List<String> terminalValues = service.getTerminalDefaultValues(attribute);
+      if (terminalValues.size() == 1) {
+        this.replaceTemplate(VALUE, attribute, new StringHookPoint("= \"" + StringEscapeUtils.escapeJava(terminalValues.get(0)) + "\""));
+      }
     }
   }
 

--- a/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/MC2CDStereotypes.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/MC2CDStereotypes.java
@@ -83,7 +83,12 @@ public enum MC2CDStereotypes {
   /**
    * To mark an interface generated from an external prod
    */
-  EXTERNAL_INTERFACE("externalInterface");
+  EXTERNAL_INTERFACE("externalInterface"),
+
+  /**
+   * To store the value of a terminal, i.e. operator:"&&"
+   */
+  TERMINAL_DEFAULT_VALUE("defaultTerminalValue");
 
   protected final String stereotype;
 

--- a/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/transl/NameTranslation.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/transl/NameTranslation.java
@@ -8,6 +8,8 @@ import de.monticore.cdbasis._ast.ASTCDCompilationUnit;
 import de.monticore.cdbasis._ast.ASTCDDefinition;
 import de.monticore.cdinterfaceandenum._ast.ASTCDEnum;
 import de.monticore.cdinterfaceandenum._ast.ASTCDInterface;
+import de.monticore.codegen.mc2cd.MC2CDStereotypes;
+import de.monticore.codegen.mc2cd.TransformationHelper;
 import de.monticore.grammar.LexNamer;
 import de.monticore.grammar.grammar._ast.*;
 import de.monticore.grammar.grammar._symboltable.RuleComponentSymbol;
@@ -77,6 +79,7 @@ public class NameTranslation implements
             Optional<String> usageName = getUsageName(rootLink.source(), link.source());
             String nameToUse = usageName.isPresent() ? usageName.get() : link.source().getName();
             link.target().setName(nameToUse);
+            TransformationHelper.addStereotypeValue(link.target().getModifier(), MC2CDStereotypes.TERMINAL_DEFAULT_VALUE.name(), link.source().getName());
         }
 
         for (Link<ASTConstantGroup, ASTCDAttribute> link : rootLink.getLinks(ASTConstantGroup.class,

--- a/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/transl/NameTranslation.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/transl/NameTranslation.java
@@ -79,7 +79,7 @@ public class NameTranslation implements
             Optional<String> usageName = getUsageName(rootLink.source(), link.source());
             String nameToUse = usageName.isPresent() ? usageName.get() : link.source().getName();
             link.target().setName(nameToUse);
-            TransformationHelper.addStereotypeValue(link.target().getModifier(), MC2CDStereotypes.TERMINAL_DEFAULT_VALUE.name(), link.source().getName());
+            TransformationHelper.addStereotypeValue(link.target().getModifier(), MC2CDStereotypes.TERMINAL_DEFAULT_VALUE.toString(), link.source().getName());
         }
 
         for (Link<ASTConstantGroup, ASTCDAttribute> link : rootLink.getLinks(ASTConstantGroup.class,

--- a/monticore-grammar/src/main/java/de/monticore/literals/MCLiteralsDecoder.java
+++ b/monticore-grammar/src/main/java/de/monticore/literals/MCLiteralsDecoder.java
@@ -3,6 +3,7 @@
 package de.monticore.literals;
 
 import de.se_rwth.commons.logging.Log;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 /**
  * This class provides methods for converting literals. The LiteralsHelper is a singleton.
@@ -57,26 +58,7 @@ public class MCLiteralsDecoder {
    * @return decoded string
    */
   public static String decodeString(String s) {
-    StringBuilder ret = new StringBuilder();
-    String in = s;
-    
-    while (in.length() != 0) {
-      if (in.charAt(0) == '\\') {
-        if (in.charAt(1) == 'u') { // unicode
-          ret.append(decodeChar(in.substring(0, 6)));
-          in = in.substring(6);
-        }
-        else { // escape sequence
-          ret.append(decodeChar(in.substring(0, 2)));
-          in = in.substring(2);
-        }
-      }
-      else { // single char
-        ret.append(in.charAt(0));
-        in = in.substring(1);
-      }
-    }
-    return ret.toString();
+    return StringEscapeUtils.unescapeJava(s);
   }
   
   /**

--- a/monticore-test/01.experiments/builderAtm/src/main/grammars/G1.mc4
+++ b/monticore-test/01.experiments/builderAtm/src/main/grammars/G1.mc4
@@ -2,4 +2,16 @@
 grammar G1 extends de.monticore.MCBasics {
   S = "...S1" a:T;
   T = "T1";
+
+  // Next, we test that the builders do not require the operator
+  TestExprMandatory = l:Name operator:"&&" r:Name;
+  TestExprMandatoryEscaped = l:Name operator:"\"hellö" r:Name;
+  TestExprOpt = l:Name operator:"OPT"? r:Name;
+  TestExprOptGroup = l:Name (operator:"OPT_GROUP")? r:Name;
+  TestExprStar = l:Name operator:"STAR"* r:Name;
+  TestExprStarGroup = l:Name (operator:"STAR_GROUP")* r:Name;
+  TestExprPlus = l:Name operator:"PLUS"+ r:Name;
+  TestExprPlusGroup = l:Name (operator:"PLUS_GROUP")+ r:Name;
+  TestExprALT = l:Name (operator:"ALT1" | operator:"ALT2") r:Name;
+
 }

--- a/monticore-test/01.experiments/builderAtm/src/test/java/G1TerminalBuildersTest.java
+++ b/monticore-test/01.experiments/builderAtm/src/test/java/G1TerminalBuildersTest.java
@@ -1,0 +1,71 @@
+/* (c) https://github.com/MontiCore/monticore */
+
+import de.monticore.runtime.junit.TestWithMCLanguage;
+import g1.G1Mill;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test that we can build expressions with a terminal present within the AST
+ * without specifying this terminal
+ */
+@TestWithMCLanguage(g1.G1Mill.class)
+public class G1TerminalBuildersTest {
+
+  @Test
+  public void testExprMandatory() {
+    var elem = G1Mill.testExprMandatoryBuilder().setL("l").setR("r").build();
+    Assertions.assertEquals("&&", elem.getOperator());
+  }
+
+  @Test
+  public void testExprMandatoryEscaped() {
+    var elem = G1Mill.testExprMandatoryEscapedBuilder().setL("l").setR("r").build();
+    Assertions.assertEquals("\"hellö", elem.getOperator());
+  }
+
+  @Test
+  public void testExprOpt() {
+    var elem = G1Mill.testExprOptBuilder().setL("l").setR("r").build();
+    Assertions.assertFalse(elem.isPresentOperator());
+  }
+
+  @Test
+  public void testExprOptGroup() {
+    var elem = G1Mill.testExprOptGroupBuilder().setL("l").setR("r").build();
+    Assertions.assertFalse(elem.isPresentOperator());
+  }
+
+  @Test
+  public void testExprStar() {
+    var elem = G1Mill.testExprStarBuilder().setL("l").setR("r").build();
+    Assertions.assertEquals(0, elem.getOperatorList().size());
+  }
+
+  @Test
+  public void testExprStarGroup() {
+    var elem = G1Mill.testExprStarGroupBuilder().setL("l").setR("r").build();
+    Assertions.assertEquals(0, elem.getOperatorList().size());
+  }
+
+  @Test
+  public void testExprPlus() {
+    // One could consider if the correct answer here should be 1
+    var elem = G1Mill.testExprPlusBuilder().setL("l").setR("r").build();
+    Assertions.assertEquals(0, elem.getOperatorList().size());
+  }
+
+  @Test
+  public void testExprPlusGroup() {
+    // One could consider if the correct answer here should be 1
+    var elem = G1Mill.testExprPlusGroupBuilder().setL("l").setR("r").build();
+    Assertions.assertEquals(0, elem.getOperatorList().size());
+  }
+
+  @Test
+  public void testExprALT() {
+    // One could consider if this should lead to an error
+    var elem = G1Mill.testExprALTBuilder().setL("l").setR("r").build();
+    Assertions.assertFalse(elem.isPresentOperator());
+  }
+}


### PR DESCRIPTION
Fix that, e.g. LogicalAndExpressions require a `setOperator("&&")` call when using their builders.

Also fix stringliteral decoding of single character length, such as `"/"`