### PR TITLE
Fix/terminal attribute order

### DIFF
--- a/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/manipul/RemoveRedundantAttributesManipulation.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/manipul/RemoveRedundantAttributesManipulation.java
@@ -12,8 +12,8 @@ import de.monticore.codegen.mc2cd.TransformationHelper;
 import de.monticore.types.mccollectiontypes._ast.ASTMCGenericType;
 import de.monticore.types.mccollectiontypes._ast.ASTMCTypeArgument;
 
+import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -42,14 +42,9 @@ final class RemoveRedundantAttributesManipulation implements UnaryOperator<ASTCD
    * @param cdAttributes the list of all the attributes in the class
    */
   List<ASTCDAttribute> removeRedundantAttributes(List<ASTCDAttribute> cdAttributes) {
-    ListIterator<ASTCDAttribute> iterator = cdAttributes.listIterator(cdAttributes.size());
-    // We iterate backwards,
-    // as the first attribute, which is created from the classprod/interface
-    // itself, should be kept.
-    // The 2nd attribute is, e.g., created by the InheritedAttributesTranslation,
-    // and should be removed as redundant
-    while (iterator.hasPrevious()) {
-      ASTCDAttribute inspectedAttribute = iterator.previous();
+    Iterator<ASTCDAttribute> iterator = cdAttributes.iterator();
+    while (iterator.hasNext()) {
+      ASTCDAttribute inspectedAttribute = iterator.next();
       List<ASTCDAttribute> remainingAttributes = cdAttributes
           .stream()
           .filter(attribute -> !attribute.equals(inspectedAttribute))
@@ -84,7 +79,25 @@ final class RemoveRedundantAttributesManipulation implements UnaryOperator<ASTCD
     boolean sameOrHigherCategory = inspectedCategory
         .compareTo(AttributeCategory.determineCategory(remainingAttribute)) < 1;
 
-    return sameName && sameType && sameOrHigherCategory;
+    if (sameName && sameType && sameOrHigherCategory) {
+      // In case multiple attributes are present:
+      // The first attribute, which is created from the classprod/interface
+      // itself, should be kept.
+      // The 2nd attribute is, e.g., created by the InheritedAttributesTranslation,
+      // and should be removed as redundant,
+      // but only IFF the second attribute does not have more stereotypes
+      // (in particular, the inherited one)
+      // [a1=Attr[name], a2=Attr[name <<inherited>]] => a2
+      // [a1=Attr[name], a2=Attr[name]] => a1
+      int inspectedStereoCount = inspectedAttribute.getModifier().isPresentStereotype()
+              ? inspectedAttribute.getModifier().getStereotype().getValuesList().size() : 0;
+      int remainingStereoCount = remainingAttribute.getModifier().isPresentStereotype()
+              ? remainingAttribute.getModifier().getStereotype().getValuesList().size() : 0;
+
+      return inspectedStereoCount < remainingStereoCount;
+    }
+
+    return false;
   }
 
   protected static String getOriginalTypeName(ASTCDAttribute cdAttribute) {

--- a/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/manipul/RemoveRedundantAttributesManipulation.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/manipul/RemoveRedundantAttributesManipulation.java
@@ -12,8 +12,8 @@ import de.monticore.codegen.mc2cd.TransformationHelper;
 import de.monticore.types.mccollectiontypes._ast.ASTMCGenericType;
 import de.monticore.types.mccollectiontypes._ast.ASTMCTypeArgument;
 
-import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -42,9 +42,14 @@ final class RemoveRedundantAttributesManipulation implements UnaryOperator<ASTCD
    * @param cdAttributes the list of all the attributes in the class
    */
   List<ASTCDAttribute> removeRedundantAttributes(List<ASTCDAttribute> cdAttributes) {
-    Iterator<ASTCDAttribute> iterator = cdAttributes.iterator();
-    while (iterator.hasNext()) {
-      ASTCDAttribute inspectedAttribute = iterator.next();
+    ListIterator<ASTCDAttribute> iterator = cdAttributes.listIterator(cdAttributes.size());
+    // We iterate backwards,
+    // as the first attribute, which is created from the classprod/interface
+    // itself, should be kept.
+    // The 2nd attribute is, e.g., created by the InheritedAttributesTranslation,
+    // and should be removed as redundant
+    while (iterator.hasPrevious()) {
+      ASTCDAttribute inspectedAttribute = iterator.previous();
       List<ASTCDAttribute> remainingAttributes = cdAttributes
           .stream()
           .filter(attribute -> !attribute.equals(inspectedAttribute))

--- a/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/manipul/RemoveRedundantAttributesManipulation.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/manipul/RemoveRedundantAttributesManipulation.java
@@ -93,6 +93,8 @@ final class RemoveRedundantAttributesManipulation implements UnaryOperator<ASTCD
    */
   protected static boolean isAttrPreferred(ASTCDAttribute candAttr,
                                            ASTCDAttribute existingAttr) {
+    // The reason behind this heuristic is documented in removeRedundantAttributes
+
     // First: check category
     AttributeCategory candCategory = determineCategory(candAttr);
     int categoryRelation = candCategory
@@ -108,7 +110,7 @@ final class RemoveRedundantAttributesManipulation implements UnaryOperator<ASTCD
     int existingStereoCount = existingAttr.getModifier().isPresentStereotype()
             ? existingAttr.getModifier().getStereotype().getValuesList().size() : 0;
     return candStereoCount > existingStereoCount;
-    // By default, the first attribute is kept
+    // The fallback heuristic is to keep the first attribute
   }
 
   protected static String getOriginalTypeName(ASTCDAttribute cdAttribute) {

--- a/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/manipul/RemoveRedundantAttributesManipulation.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/manipul/RemoveRedundantAttributesManipulation.java
@@ -12,11 +12,10 @@ import de.monticore.codegen.mc2cd.TransformationHelper;
 import de.monticore.types.mccollectiontypes._ast.ASTMCGenericType;
 import de.monticore.types.mccollectiontypes._ast.ASTMCTypeArgument;
 
-import java.util.Iterator;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
 
 import static de.monticore.codegen.mc2cd.AttributeCategory.determineCategory;
 
@@ -42,67 +41,74 @@ final class RemoveRedundantAttributesManipulation implements UnaryOperator<ASTCD
    * @param cdAttributes the list of all the attributes in the class
    */
   List<ASTCDAttribute> removeRedundantAttributes(List<ASTCDAttribute> cdAttributes) {
-    Iterator<ASTCDAttribute> iterator = cdAttributes.iterator();
-    while (iterator.hasNext()) {
-      ASTCDAttribute inspectedAttribute = iterator.next();
-      List<ASTCDAttribute> remainingAttributes = cdAttributes
-          .stream()
-          .filter(attribute -> !attribute.equals(inspectedAttribute))
-          .collect(Collectors.toList());
-      boolean isRedundant = remainingAttributes
-          .stream()
-          .anyMatch(a -> isRedundant(inspectedAttribute, a));
-      if (isRedundant) {
-        iterator.remove();
+    List<ASTCDAttribute> uniqueAttributes = new ArrayList<>();
+    // In case multiple attributes (with the same name & type) are present:
+    // The first attribute, which is created from the classprod/interface
+    // itself, should be kept.
+    // The 2nd attribute is, e.g., created by the InheritedAttributesTranslation,
+    // and should be removed as redundant,
+    // but only IFF the second attribute does not have more stereotypes
+    // (in particular, the inherited one)
+    // [a1=Attr[name], a2=Attr[name <<inherited>]] => a2
+    // [a1=Attr[name], a2=Attr[name]] => a1
+    // in addition, the attribute with the highest category is kept
+    outer:
+    for (ASTCDAttribute cdAttributeCand : cdAttributes) {
+      for (int i = 0; i < uniqueAttributes.size(); i++) {
+        ASTCDAttribute existingAttribute = uniqueAttributes.get(i);
+        if (isColliding(cdAttributeCand, existingAttribute)) {
+          if (isAttrPreferred(cdAttributeCand, existingAttribute)) {
+            uniqueAttributes.set(i, cdAttributeCand);
+          }
+          continue outer;
+        }
       }
+      uniqueAttributes.add(cdAttributeCand);
     }
-    return cdAttributes;
+    return uniqueAttributes;
   }
 
   /**
-   * Checks if the remaining attributes contain an attribute that makes the inspected attribute
-   * redundant.
+   * Checks if the two attributes collide, i.e. share the same name & (original) type
    *
-   * @return true if another attribute with the same variable name, the same original type and an
-   * equal or higher category exists
+   * @return true if another attribute with the same variable name, the same original type exists
    */
-  protected static boolean isRedundant(ASTCDAttribute inspectedAttribute,
-                                     ASTCDAttribute remainingAttribute) {
+  protected static boolean isColliding(ASTCDAttribute inspectedAttribute,
+                                       ASTCDAttribute remainingAttribute) {
     String inspectedName = inspectedAttribute.getName();
     String inspectedType = getOriginalTypeName(inspectedAttribute);
-    AttributeCategory inspectedCategory = determineCategory(inspectedAttribute);
 
     boolean sameName = inspectedName.equalsIgnoreCase(remainingAttribute.getName());
 
     boolean sameType = inspectedType.equals(getOriginalTypeName(remainingAttribute));
 
-    // to check for sameOrHigherCategory
-    int categoryRelation = inspectedCategory
-        .compareTo(AttributeCategory.determineCategory(remainingAttribute));
+    return sameName && sameType;
+  }
 
-    if (sameName && sameType && categoryRelation < 0) {
-      // of higher category -> redundant
+  /**
+   * Checks if the candidate should replace the existing attribute:
+   * - if it has a higher category, in case the same category is used:
+   * - if the candidate has more stereotypes (in particular inherited)
+   * @return true if the candAttr should be preferred over the existing one
+   */
+  protected static boolean isAttrPreferred(ASTCDAttribute candAttr,
+                                           ASTCDAttribute existingAttr) {
+    // First: check category
+    AttributeCategory candCategory = determineCategory(candAttr);
+    int categoryRelation = candCategory
+            .compareTo(AttributeCategory.determineCategory(existingAttr));
+    if (categoryRelation < 0) {
+      return false;
+    } else if (categoryRelation > 0) {
       return true;
-    } else if (sameName && sameType && categoryRelation == 0) {
-      // of the same category:
-      // In case multiple attributes are present:
-      // The first attribute, which is created from the classprod/interface
-      // itself, should be kept.
-      // The 2nd attribute is, e.g., created by the InheritedAttributesTranslation,
-      // and should be removed as redundant,
-      // but only IFF the second attribute does not have more stereotypes
-      // (in particular, the inherited one)
-      // [a1=Attr[name], a2=Attr[name <<inherited>]] => a2
-      // [a1=Attr[name], a2=Attr[name]] => a1
-      int inspectedStereoCount = inspectedAttribute.getModifier().isPresentStereotype()
-              ? inspectedAttribute.getModifier().getStereotype().getValuesList().size() : 0;
-      int remainingStereoCount = remainingAttribute.getModifier().isPresentStereotype()
-              ? remainingAttribute.getModifier().getStereotype().getValuesList().size() : 0;
-
-      return inspectedStereoCount < remainingStereoCount;
     }
-
-    return false;
+    // The same category: check stereo counts to keep inherited
+    int candStereoCount = candAttr.getModifier().isPresentStereotype()
+            ? candAttr.getModifier().getStereotype().getValuesList().size() : 0;
+    int existingStereoCount = existingAttr.getModifier().isPresentStereotype()
+            ? existingAttr.getModifier().getStereotype().getValuesList().size() : 0;
+    return candStereoCount > existingStereoCount;
+    // By default, the first attribute is kept
   }
 
   protected static String getOriginalTypeName(ASTCDAttribute cdAttribute) {

--- a/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/manipul/RemoveRedundantAttributesManipulation.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/manipul/RemoveRedundantAttributesManipulation.java
@@ -76,10 +76,15 @@ final class RemoveRedundantAttributesManipulation implements UnaryOperator<ASTCD
 
     boolean sameType = inspectedType.equals(getOriginalTypeName(remainingAttribute));
 
-    boolean sameOrHigherCategory = inspectedCategory
-        .compareTo(AttributeCategory.determineCategory(remainingAttribute)) < 1;
+    // to check for sameOrHigherCategory
+    int categoryRelation = inspectedCategory
+        .compareTo(AttributeCategory.determineCategory(remainingAttribute));
 
-    if (sameName && sameType && sameOrHigherCategory) {
+    if (sameName && sameType && categoryRelation < 0) {
+      // of higher category -> redundant
+      return true;
+    } else if (sameName && sameType && categoryRelation == 0) {
+      // of the same category:
       // In case multiple attributes are present:
       // The first attribute, which is created from the classprod/interface
       // itself, should be kept.

--- a/monticore-generator/src/test/java/de/monticore/codegen/mc2cd/manipul/RemoveRedundantReferencesManipulationTest.java
+++ b/monticore-generator/src/test/java/de/monticore/codegen/mc2cd/manipul/RemoveRedundantReferencesManipulationTest.java
@@ -40,10 +40,12 @@ public class RemoveRedundantReferencesManipulationTest extends TranslationTestCa
     ASTCDAttribute singleAttribute = CD4AnalysisMill.cDAttributeBuilder().uncheckedBuild();
     singleAttribute.setName(firstReferenceName);
     singleAttribute.setMCType(firstReferenceType);
-    
+    singleAttribute.setModifier(CD4AnalysisMill.modifierBuilder().uncheckedBuild());
+
     ASTCDAttribute listAttribute = CD4AnalysisMill.cDAttributeBuilder().uncheckedBuild();
     listAttribute.setName(secondReferenceName);
     listAttribute.setMCType(secondReferenceType);
+    listAttribute.setModifier(CD4AnalysisMill.modifierBuilder().uncheckedBuild());
     
     cdClass.addCDMember(singleAttribute);
     cdClass.addCDMember(listAttribute);

--- a/monticore-grammar/src/test/java/de/monticore/expressions/commonexpressions/CommonExpressionsBuilderTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/expressions/commonexpressions/CommonExpressionsBuilderTest.java
@@ -1,0 +1,21 @@
+/* (c) https://github.com/MontiCore/monticore */
+
+package de.monticore.expressions.commonexpressions;
+
+import de.monticore.runtime.junit.TestWithMCLanguage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@TestWithMCLanguage(CommonExpressionsMill.class)
+public class CommonExpressionsBuilderTest {
+  @Test
+  public void testBooleanAndOpExpression() {
+    // Test that we can build a && expression without specifying the operator
+    var elem = CommonExpressionsMill.booleanAndOpExpressionBuilder()
+            .setLeft(CommonExpressionsMill.nameExpressionBuilder().setName("l").build())
+            .setRight(CommonExpressionsMill.nameExpressionBuilder().setName("r").build())
+            .build();
+    // And that the actual operator is "&&" (instead of "" from the infix operator)
+    Assertions.assertEquals("&&", elem.getOperator());
+  }
+}

--- a/monticore-test/01.experiments/builderAtm/src/main/grammars/G1.mc4
+++ b/monticore-test/01.experiments/builderAtm/src/main/grammars/G1.mc4
@@ -15,10 +15,11 @@ grammar G1 extends de.monticore.MCBasics {
   TestExprALT = l:Name (operator:"ALT1" | operator:"ALT2") r:Name;
 
   // Test the same with inheritance and duplicate attributes
-	interface TestExpression;
-	TestBooleanAndOpExpression implements TestExpression <120>, TestInfixExpression =
-		left:TestExpression operator:"&&" right:TestExpression;
-	interface TestInfixExpression =
-						left:TestExpression operator:"" right:TestExpression;
-	TestNameE implements TestExpression = Name;
+  interface TestExpression;
+  TestBooleanAndOpExpression implements TestExpression <120>, TestInfixExpression =
+    left:TestExpression operator:"&&" right:TestExpression;
+  interface TestInfixExpression =
+    left:TestExpression operator:"" right:TestExpression;
+  TestNameE implements TestExpression = Name;
+
 }

--- a/monticore-test/01.experiments/builderAtm/src/main/grammars/G1.mc4
+++ b/monticore-test/01.experiments/builderAtm/src/main/grammars/G1.mc4
@@ -14,4 +14,11 @@ grammar G1 extends de.monticore.MCBasics {
   TestExprPlusGroup = l:Name (operator:"PLUS_GROUP")+ r:Name;
   TestExprALT = l:Name (operator:"ALT1" | operator:"ALT2") r:Name;
 
+  // Test the same with inheritance and duplicate attributes
+	interface TestExpression;
+	TestBooleanAndOpExpression implements TestExpression <120>, TestInfixExpression =
+		left:TestExpression operator:"&&" right:TestExpression;
+	interface TestInfixExpression =
+						left:TestExpression operator:"" right:TestExpression;
+	TestNameE implements TestExpression = Name;
 }

--- a/monticore-test/01.experiments/builderAtm/src/test/java/G1TerminalBuildersTest.java
+++ b/monticore-test/01.experiments/builderAtm/src/test/java/G1TerminalBuildersTest.java
@@ -68,4 +68,18 @@ public class G1TerminalBuildersTest {
     var elem = G1Mill.testExprALTBuilder().setL("l").setR("r").build();
     Assertions.assertFalse(elem.isPresentOperator());
   }
+
+  @Test
+  public void testBooleanAndOpExpression() {
+    // First, check that we can still call build() without an operator
+    var elem = G1Mill.testBooleanAndOpExpressionBuilder()
+            .setLeft(G1Mill.testNameEBuilder().setName("l").build())
+            .setRight(G1Mill.testNameEBuilder().setName("r").build())
+            .build();
+    // With duplicate attributes: Check that the correct operator-attribute was used
+    Assertions.assertEquals("&&", elem.getOperator());
+    // The InfixExpression's operator:"" MUST not match
+    // (and yes, this is a redundant check)
+    Assertions.assertNotEquals("", elem.getOperator());
+  }
 }


### PR DESCRIPTION
In addition to #167 

Interfaces with ast-present terminals (such as `InfixExpressions`) result in multiple attributes within the CD.
The last attribute used to be kept, resulting in `BooleanAndOpExpression implements Expression <120>, InfixExpression =
    left:Expression operator:"&&" right:Expression;` having the `operator` default being `""` (from the `InfixExpression`)

This PR modifies the removal of redundant attributes, by
 * cleaning up the code
 * preferring the attribute with the highest category (i.e., List), then the highest count of stereotypes (i.e., `<<inherited>>`), and finally prefers the first attribute (which is the original one) over later ones (e.g., from the infixexpression interface)