### PR TITLE
Improve next release preparation

### DIFF
--- a/.github/workflows/gradle_mc.yml
+++ b/.github/workflows/gradle_mc.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Apply patches to look into the future
         run: sh ./prepare-next-release/applyPatches.sh
       - name: Build a subset of the monticore project
-        run: gradle monticore-generator:build monticore-grammar:build monticore-test:02.experiments:check  ${{env.GRADLE_CLI_OPTS}}
+        run: gradle monticore-generator:build monticore-grammar:build monticore-test:02experiments:check  ${{env.GRADLE_CLI_OPTS}}
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
         if: always() # always run even if the previous step fails

--- a/.github/workflows/gradle_mc.yml
+++ b/.github/workflows/gradle_mc.yml
@@ -191,6 +191,8 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: ${{env.GRADLE_VERSION}}
+      - name: Setup git
+        run: git config --global user.email "ci@monticore.de" && git config --global user.name "ci"
       - name: Apply patches to look into the future
         run: sh ./prepare-next-release/applyPatches.sh
       - name: Build a subset of the monticore project

--- a/.github/workflows/gradle_mc.yml
+++ b/.github/workflows/gradle_mc.yml
@@ -192,7 +192,7 @@ jobs:
         with:
           gradle-version: ${{env.GRADLE_VERSION}}
       - name: Apply patches to look into the future
-        run: ./prepare-next-release/applyPatches.sh
+        run: sh ./prepare-next-release/applyPatches.sh
       - name: Build a subset of the monticore project
         run: gradle monticore-generator:build monticore-grammar:build monticore-test:02.experiments:check  ${{env.GRADLE_CLI_OPTS}}
       - name: Publish Test Report

--- a/.github/workflows/gradle_mc.yml
+++ b/.github/workflows/gradle_mc.yml
@@ -180,6 +180,27 @@ jobs:
         with:
           report_paths: '**/target/test-results/test/TEST-*.xml'
 
+  # Look ahead in time to check if this would break the next MC release
+  test-for-breaking-changes:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name # do not run duplicate jobs on PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project sources
+        uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: ${{env.GRADLE_VERSION}}
+      - name: Apply patches to look into the future
+        run: ./prepare-next-release/applyPatches.sh
+      - name: Build a subset of the monticore project
+        run: gradle monticore-generator:build monticore-grammar:build monticore-test:02.experiments:check  ${{env.GRADLE_CLI_OPTS}}
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@a451de5ac1ff45e46508b6150cb4f51a287d0309
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/target/test-results/test/TEST-*.xml'
+
   # Run the MontiVerse pipeline (tests this change on a suite of projects)
   trigger-montiverse:
     if: github.event_name == 'pull_request' # only run on PRs

--- a/prepare-next-release/0001-use-next-snapshot.patch
+++ b/prepare-next-release/0001-use-next-snapshot.patch
@@ -1,0 +1,56 @@
+From fada35ac7be1e5dcd185f33b331cf9fc7ce3fff5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alex=20L=C3=BCpges?= <luepges@se-rwth.de>
+Date: Wed, 16 Jul 2025 12:20:05 +0200
+Subject: [PATCH] use next snapshot
+
+
+diff --git a/gradle.properties b/gradle.properties
+index d18c43197..380c8f98f 100644
+--- a/gradle.properties
++++ b/gradle.properties
+@@ -14,11 +14,11 @@ org.gradle.caching=true
+ # org.gradle.caching.debug=true
+ 
+ # versions used
+-version=7.8.0-SNAPSHOT
+-previous_mc_version =7.7.0
++version=7.9.0-SNAPSHOT
++previous_mc_version =7.8.0-SNAPSHOT
+ 
+ commons_cli_version = 1.4
+-se_commons_version =7.7.0
++se_commons_version =7.8.0-SNAPSHOT
+ antlr_version =4.12.0
+ junit_version =5.10.3
+ emf_compare_version =1.2.0
+@@ -28,4 +28,4 @@ freemarker_version = 2.3.34
+ guava_version =31.1-jre
+ shadow_plugin_version=7.1.2
+ 
+-cd4a_version =7.7.0
++cd4a_version =7.8.0-SNAPSHOT
+diff --git a/monticore-generator/gradle.properties b/monticore-generator/gradle.properties
+index 55fa093b2..1aaebe45f 100644
+--- a/monticore-generator/gradle.properties
++++ b/monticore-generator/gradle.properties
+@@ -9,13 +9,13 @@ useLocalRepo=true
+ showTestOutput=false
+ 
+ # versions used
+-version=7.8.0-SNAPSHOT
+-previous_mc_version =7.7.0
++version=7.9.0-SNAPSHOT
++previous_mc_version =7.8.0-SNAPSHOT
+ 
+-se_commons_version =7.7.0
++se_commons_version =7.8.0-SNAPSHOT
+ antlr_version =4.12.0
+ junit_version =5.10.3
+-cd4a_version =7.7.0
++cd4a_version =7.8.0-SNAPSHOT
+ commons_lang3_version = 3.8.1
+ commons_cli_version = 1.4
+ freemarker_version = 2.3.28
+-- 
+2.42.0.windows.2
+

--- a/prepare-next-release/0001-use-next-snapshot.patch
+++ b/prepare-next-release/0001-use-next-snapshot.patch
@@ -1,4 +1,4 @@
-From fada35ac7be1e5dcd185f33b331cf9fc7ce3fff5 Mon Sep 17 00:00:00 2001
+From 16f1393eaeca8c8fc6dffa2616f3c9c8091ff0aa Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alex=20L=C3=BCpges?= <luepges@se-rwth.de>
 Date: Wed, 16 Jul 2025 12:20:05 +0200
 Subject: [PATCH] use next snapshot

--- a/prepare-next-release/0002-Replace-ASTStereoValue-setText.patch
+++ b/prepare-next-release/0002-Replace-ASTStereoValue-setText.patch
@@ -1,0 +1,23 @@
+From 54109965fdb66a5133dc848ee0a244fbc30032fd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alex=20L=C3=BCpges?= <luepges@se-rwth.de>
+Date: Wed, 16 Jul 2025 13:20:22 +0200
+Subject: [PATCH] Replace ASTStereoValue#setText
+
+
+diff --git a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/AbstractService.java b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/AbstractService.java
+index e50a5e17d..35c9eff4f 100644
+--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/AbstractService.java
++++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/AbstractService.java
+@@ -444,8 +444,7 @@ public class AbstractService<T extends AbstractService> {
+     ASTStereoValue stereoValue = CD4AnalysisMill.stereoValueBuilder()
+             .setName(MC2CDStereotypes.DEPRECATED.toString()).uncheckedBuild();
+     if (deprecatedValue.isPresent()) {
+-      stereoValue.setText(
+-              CD4AnalysisMill.stringLiteralBuilder().setSource(deprecatedValue.get()).build());
++      stereoValue.setContent(deprecatedValue.get());
+     }
+     stereoValueList.add(stereoValue);
+   }
+-- 
+2.42.0.windows.2
+

--- a/prepare-next-release/0002-Replace-ASTStereoValue-setText.patch
+++ b/prepare-next-release/0002-Replace-ASTStereoValue-setText.patch
@@ -1,4 +1,4 @@
-From 54109965fdb66a5133dc848ee0a244fbc30032fd Mon Sep 17 00:00:00 2001
+From 6891c303f3b16db88964642a3ff991bb8edb9bb0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Alex=20L=C3=BCpges?= <luepges@se-rwth.de>
 Date: Wed, 16 Jul 2025 13:20:22 +0200
 Subject: [PATCH] Replace ASTStereoValue#setText

--- a/prepare-next-release/0003-change-symtabdefinition-plugin-version.patch
+++ b/prepare-next-release/0003-change-symtabdefinition-plugin-version.patch
@@ -1,0 +1,22 @@
+From 671d244c01307d03a8285b84a60dfae413074c74 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alex=20L=C3=BCpges?= <luepges@se-rwth.de>
+Date: Wed, 16 Jul 2025 15:16:50 +0200
+Subject: [PATCH] change symtabdefinition plugin version
+
+
+diff --git a/monticore-libraries/stream-symbols/build.gradle b/monticore-libraries/stream-symbols/build.gradle
+index f730fbb39..fbca4c40e 100644
+--- a/monticore-libraries/stream-symbols/build.gradle
++++ b/monticore-libraries/stream-symbols/build.gradle
+@@ -1,6 +1,7 @@
+ /* (c) https://github.com/MontiCore/monticore */
+ plugins {
+-  id "de.rwth.se.symtabdefinition" version "$version"
++  id "de.rwth.se.symtabdefinition" version "$previous_mc_version"
++  // use previous_mc_version to avoid bootstrapping issue
+ }
+ 
+ description = 'MontiCore: Stream Symbols'
+-- 
+2.42.0.windows.2
+

--- a/prepare-next-release/0004-initialize-type-system-3.patch
+++ b/prepare-next-release/0004-initialize-type-system-3.patch
@@ -1,0 +1,62 @@
+From b6baf36a9e7b32cdf653b6444a2e1ebf87649de7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alex=20L=C3=BCpges?= <luepges@se-rwth.de>
+Date: Wed, 16 Jul 2025 16:46:16 +0200
+Subject: [PATCH] initialize type system 3
+
+
+diff --git a/monticore-generator/src/main/java/de/monticore/cli/MontiCoreTool.java b/monticore-generator/src/main/java/de/monticore/cli/MontiCoreTool.java
+index b49061618..f9e97477a 100644
+--- a/monticore-generator/src/main/java/de/monticore/cli/MontiCoreTool.java
++++ b/monticore-generator/src/main/java/de/monticore/cli/MontiCoreTool.java
+@@ -13,7 +13,11 @@ import de.monticore.StatisticsHandlerFix;
+ import de.monticore.cli.updateChecker.UpdateCheckerRunnable;
+ import de.monticore.generating.templateengine.reporting.Reporting;
+ import de.monticore.grammar.grammar_withconcepts.Grammar_WithConceptsMill;
+-import de.monticore.io.FileReaderWriterFix;
++import de.monticore.grammar.grammar_withconcepts._visitor.Grammar_WithConceptsTraverser;
++import de.monticore.literals.mccommonliterals.types3.MCCommonLiteralsTypeVisitor;
++import de.monticore.types.mcbasictypes.types3.MCBasicTypesTypeVisitor;
++import de.monticore.types3.Type4Ast;
++import de.monticore.types3.util.MapBasedTypeCheck3;
+ import de.se_rwth.commons.logging.Log;
+ import de.se_rwth.commons.logging.Slf4jLog;
+ import org.apache.commons.cli.*;
+@@ -124,6 +128,8 @@ public class MontiCoreTool {
+       
+       // load custom or default script
+       String script = loadScript(cmd);
++
++      initializeTypeCheck3();
+       
+       // execute MontiCore with loaded script and configuration
+       new MontiCoreScript().run(script, configuration);
+@@ -276,6 +282,26 @@ public class MontiCoreTool {
+     return script;
+   }
+ 
++  /**
++   * Initialize the TypeSystem(3)
++   */
++  public void initializeTypeCheck3() {
++    Grammar_WithConceptsTraverser traverser = Grammar_WithConceptsMill.traverser();
++
++    // map to store the results
++    Type4Ast type4Ast = new Type4Ast();
++
++    MCCommonLiteralsTypeVisitor visMCCommonLiterals = new MCCommonLiteralsTypeVisitor();
++    visMCCommonLiterals.setType4Ast(type4Ast);
++    traverser.add4MCCommonLiterals(visMCCommonLiterals);
++
++    MCBasicTypesTypeVisitor visMCBasicTypes = new MCBasicTypesTypeVisitor();
++    visMCBasicTypes.setType4Ast(type4Ast);
++    traverser.add4MCBasicTypes(visMCBasicTypes);
++
++    new MapBasedTypeCheck3(traverser, type4Ast).setThisAsDelegate();
++  }
++
+   /*=================================================================*/
+   /* Part 3: Defining the options incl. help-texts
+   /*=================================================================*/
+-- 
+2.42.0.windows.2
+

--- a/prepare-next-release/0005-use-inheritance-traverser-with-cds.patch
+++ b/prepare-next-release/0005-use-inheritance-traverser-with-cds.patch
@@ -1,0 +1,48 @@
+From 322ba8a376cda68535db6e9f89bc99fcc9c8c16a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alex=20L=C3=BCpges?= <luepges@se-rwth.de>
+Date: Thu, 17 Jul 2025 13:27:35 +0200
+Subject: [PATCH] use inheritance traverser with cds
+
+
+diff --git a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/typecd2java/TypeCD2JavaDecorator.java b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/typecd2java/TypeCD2JavaDecorator.java
+index 464e8da50..aaf4164d4 100644
+--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/typecd2java/TypeCD2JavaDecorator.java
++++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/typecd2java/TypeCD2JavaDecorator.java
+@@ -17,7 +17,7 @@ public class TypeCD2JavaDecorator extends AbstractCreator<ASTCDCompilationUnit,
+ 
+   @Override
+   public ASTCDCompilationUnit decorate(final ASTCDCompilationUnit compilationUnit) {
+-    CD4CodeTraverser traverser = CD4CodeMill.traverser();
++    CD4CodeTraverser traverser = CD4CodeMill.inheritanceTraverser();
+     traverser.add4MCBasicTypes(new TypeCD2JavaVisitor(scope));
+     compilationUnit.accept(traverser);
+     return compilationUnit;
+diff --git a/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/MC2CD4CodeSymbolTableCompleter.java b/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/MC2CD4CodeSymbolTableCompleter.java
+index aba629201..704267049 100644
+--- a/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/MC2CD4CodeSymbolTableCompleter.java
++++ b/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/MC2CD4CodeSymbolTableCompleter.java
+@@ -14,7 +14,7 @@ public class MC2CD4CodeSymbolTableCompleter {
+ 
+ 
+   public MC2CD4CodeSymbolTableCompleter() {
+-    this.traverser = CD4CodeMill.traverser();
++    this.traverser = CD4CodeMill.inheritanceTraverser();
+ 
+     //New!
+     FullSynthesizeFromMCSGT4Grammar synthesize = new FullSynthesizeFromMCSGT4Grammar();
+diff --git a/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/manipul/JavaAndCdConformNameManipulation.java b/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/manipul/JavaAndCdConformNameManipulation.java
+index ef6ff639a..93b64ccf9 100644
+--- a/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/manipul/JavaAndCdConformNameManipulation.java
++++ b/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/manipul/JavaAndCdConformNameManipulation.java
+@@ -23,7 +23,7 @@ public class JavaAndCdConformNameManipulation implements UnaryOperator<ASTCDComp
+ 
+   @Override
+   public ASTCDCompilationUnit apply(ASTCDCompilationUnit cdCompilationUnit) {
+-    CD4AnalysisTraverser traverser = CD4AnalysisMill.traverser();
++    CD4AnalysisTraverser traverser = CD4AnalysisMill.inheritanceTraverser();
+     traverser.add4CDBasis(new ManipulateVisitor(cdCompilationUnit.getCDPackageList(), cdCompilationUnit.getCDDefinition().getName()));
+     cdCompilationUnit.accept(traverser);
+     return cdCompilationUnit;
+-- 
+2.45.1.windows.1
+

--- a/prepare-next-release/PreparingTheNextRelease.md
+++ b/prepare-next-release/PreparingTheNextRelease.md
@@ -18,7 +18,7 @@ Work in your git branch, but please do not have any local, uncommited changes.
 You can reset your local working tree via `git reset --hard yourBranchName`
 
 Apply all previous patches: `./prepare-next-release/applyPatches.sh`
-(this applies all patch files and switches a new branch)
+(this applies all patch files and switches to a new branch)
 
 Modify the source files and ensure that the previously failing tests now work.
 Then create a commit as usual

--- a/prepare-next-release/PreparingTheNextRelease.md
+++ b/prepare-next-release/PreparingTheNextRelease.md
@@ -1,39 +1,44 @@
 <!-- (c) https://github.com/MontiCore/monticore -->
 
 Due to MontiCore bootstrapping itself via the grammar and cd DSLs,
- creating the next snapshot version is always a hassle.
+creating the next snapshot version is always a hassle.
 This directory aims to catch breaking changes of the new version early
- and collects patches for the next release.
+and collects patches for the next release.
 
 To this aim, git patches with the required changes are collected in this directory.
 
-> This document is still work in progress
-
+> This document is still a work in progress
 
 ## Your PR breaks the next MontiCore release
-Please create a patch for your changes, such that the next MontiCore releases is easier.
+
+Please create a patch for your changes,
+such that the next MontiCore release is easier.
 
 Work in your git branch, but please do not have any local, uncommited changes.
 You can reset your local working tree via `git reset --hard yourBranchName`
 
-Apply all previous patches: `./prepare-next-release/applyPatches.sh` 
-(this applies all patch files & switches a new branch)
+Apply all previous patches: `./prepare-next-release/applyPatches.sh`
+(this applies all patch files and switches a new branch)
 
-Modify the source files and ensure, that the previously failing tests now work.
+Modify the source files and ensure that the previously failing tests now work.
 Then create a commit as usual
-(e.g., `git add <file>` & `git commit -m <msg>`)
-To build the patch file and change back to your original branch, 
- use: `./prepare-next-release/buildPatches.sh`
+(e.g., `git add <file>` & `git commit -m <msg>`).
+To build the patch file and change back to your original branch,
+use: `./prepare-next-release/buildPatches.sh`
 
 We can't commit and push the soon-to-be-required changes to the repository.
-Instead, add & commit the patch file to your branch.
+Instead, add and commit the patch file to your branch.
 (This patch file will now be used after building the next release.)
+(You can ignore the changes to the hash of the previous patch files.)
+
+_Note: Any breaking changes in upstream projects may trigger the build jobs failure._
 
 ## Post-Release work
+
 Congratulations, you have just released MontiCore, etc.
 
 * Delete the first patch file (as it uses the snapshot version instead of full releases)
-* Next, apply all remaining patches & push them. 
-* Remove all patch files & recreate the first patch, by using the next snapshot version. 
-The first patch, 0001-..., should always update the various versions.
+* Next, apply all remaining patches & push them.
+* Remove all patch files & recreate the first patch, by using the next snapshot version.
+  The first patch, 0001-..., should always update the various versions.
 

--- a/prepare-next-release/PreparingTheNextRelease.md
+++ b/prepare-next-release/PreparingTheNextRelease.md
@@ -1,0 +1,39 @@
+<!-- (c) https://github.com/MontiCore/monticore -->
+
+Due to MontiCore bootstrapping itself via the grammar and cd DSLs,
+ creating the next snapshot version is always a hassle.
+This directory aims to catch breaking changes of the new version early
+ and collects patches for the next release.
+
+To this aim, git patches with the required changes are collected in this directory.
+
+> This document is still work in progress
+
+
+## Your PR breaks the next MontiCore release
+Please create a patch for your changes, such that the next MontiCore releases is easier.
+
+Work in your git branch, but please do not have any local, uncommited changes.
+You can reset your local working tree via `git reset --hard yourBranchName`
+
+Apply all previous patches: `./prepare-next-release/applyPatches.sh` 
+(this applies all patch files & switches a new branch)
+
+Modify the source files and ensure, that the previously failing tests now work.
+Then create a commit as usual
+(e.g., `git add <file>` & `git commit -m <msg>`)
+To build the patch file and change back to your original branch, 
+ use: `./prepare-next-release/buildPatches.sh`
+
+We can't commit and push the soon-to-be-required changes to the repository.
+Instead, add & commit the patch file to your branch.
+(This patch file will now be used after building the next release.)
+
+## Post-Release work
+Congratulations, you have just released MontiCore, etc.
+
+* Delete the first patch file (as it uses the snapshot version instead of full releases)
+* Next, apply all remaining patches & push them. 
+* Remove all patch files & recreate the first patch, by using the next snapshot version. 
+The first patch, 0001-..., should always update the various versions.
+

--- a/prepare-next-release/applyPatches.sh
+++ b/prepare-next-release/applyPatches.sh
@@ -1,0 +1,21 @@
+#! /bin/sh
+# (c) https://github.com/MontiCore/monticore
+# Script for applying all patches to check if we are about to break the next release of MontiCore
+
+# Start by switching to a new branch (using the suffix -crystal-ball)
+currentBranch=`git rev-parse --abbrev-ref HEAD`
+git checkout -b $currentBranch-crystal-ball
+if [ "$?" != "0" ]; then
+    echo "Failed to switch to new branch $currentBranch-crystal-ball"
+    exit 1
+fi
+# And apply all patches
+git am --abort >/dev/null 2>&1
+git am --3way prepare-next-release/*.patch
+if [ "$?" != "0" ]; then
+    echo "Failed to apply the patches."
+    echo "Please consult the 'PreparingTheNextRelease' documentation "
+    exit 1
+else
+    echo "Cleanly applied patches"
+fi

--- a/prepare-next-release/applyPatches.sh
+++ b/prepare-next-release/applyPatches.sh
@@ -4,6 +4,12 @@
 
 # Start by switching to a new branch (using the suffix -crystal-ball)
 currentBranch=`git rev-parse --abbrev-ref HEAD`
+
+if [[ "$currentBranch" == *"-crystal-ball"* ]]; then
+  echo "Script may not be executed on a branch with applied patches!"
+  exit 1
+fi
+
 git checkout -b $currentBranch-crystal-ball
 if [ "$?" != "0" ]; then
     echo "Failed to switch to new branch $currentBranch-crystal-ball"

--- a/prepare-next-release/applyPatches.sh
+++ b/prepare-next-release/applyPatches.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 # (c) https://github.com/MontiCore/monticore
 # Script for applying all patches to check if we are about to break the next release of MontiCore
 

--- a/prepare-next-release/applyPatches.sh
+++ b/prepare-next-release/applyPatches.sh
@@ -10,6 +10,13 @@ if [[ "$currentBranch" == *"-crystal-ball"* ]]; then
   exit 1
 fi
 
+git diff-index --quiet --cached HEAD --
+if [ "$?" != "0" ]; then
+    echo "Dirty index: won't be able to apply patched"
+    git diff-index --cached HEAD --
+    exit 1
+fi
+
 git checkout -b $currentBranch-crystal-ball
 if [ "$?" != "0" ]; then
     echo "Failed to switch to new branch $currentBranch-crystal-ball"

--- a/prepare-next-release/buildPatches.sh
+++ b/prepare-next-release/buildPatches.sh
@@ -4,10 +4,15 @@
 
 
 currentBranch=`git rev-parse --abbrev-ref HEAD`
+
+if [[ "$currentBranch" != *"-crystal-ball"* ]]; then
+  echo "Script may only be executed on a branch with applied patches!"
+  exit 1
+fi
 originalBranch="${currentBranch/-crystal-ball/}"
 
 echo "Creating patch difference to $originalBranch"
-git format-patch --no-stat --minimal -N -o .\prepare-next-release\ $originalBranch --
+git format-patch --no-stat --minimal -N -o ./prepare-next-release/ $originalBranch --
 if [ "$?" != "0" ]; then
     echo "Failed to create patch differences"
     exit 1

--- a/prepare-next-release/buildPatches.sh
+++ b/prepare-next-release/buildPatches.sh
@@ -1,0 +1,16 @@
+#! /bin/sh
+# (c) https://github.com/MontiCore/monticore
+# Script for creating new patch files
+
+
+currentBranch=`git rev-parse --abbrev-ref HEAD`
+originalBranch="${currentBranch/-crystal-ball/}"
+
+echo "Creating patch difference to $originalBranch"
+git format-patch --no-stat --minimal -N -o .\prepare-next-release\ $originalBranch --
+if [ "$?" != "0" ]; then
+    echo "Failed to create patch differences"
+    exit 1
+fi
+echo "Switching back to branch: $originalBranch"
+git checkout $originalBranch

--- a/prepare-next-release/buildPatches.sh
+++ b/prepare-next-release/buildPatches.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 # (c) https://github.com/MontiCore/monticore
 # Script for creating new patch files
 


### PR DESCRIPTION
To avoid the headache of beaking changes after the next release,
this PR aims to detect breaking changes earlier.

In addition, any breaking changes that are going to break the next version (as in, the snapshot right after a release) in the future,
should provide the required patch.

* new github job that builds the next version of the generator, grammar, and 02.experiments from the current snapshot (assuming, the current snapshot results in a release)
* patch system for in-the-future-required changes