### PR TITLE
Fix project#getGroup() not being respected

### DIFF
--- a/monticore-generator/src/main/java/de/monticore/gradle/dependencies/MCPublishingPlugin.java
+++ b/monticore-generator/src/main/java/de/monticore/gradle/dependencies/MCPublishingPlugin.java
@@ -24,7 +24,6 @@ import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.internal.JavaConfigurationVariantMapping;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.internal.publication.DefaultMavenPublication;
@@ -218,32 +217,46 @@ public class MCPublishingPlugin implements Plugin<Project> {
       evalProj.getPluginManager().withPlugin("maven-publish", mavenPublishPlugin -> {
         evalProj.getExtensions().configure(PublishingExtension.class, publExt -> {
           // Set up a Maven publication for non-main source sets
-          publExt.getPublications().create(sourceSet.getName(), MavenPublication.class, mavenPublication -> {
-            // And append the source set name as an appendix to the artifact id
-            mavenPublication.setArtifactId(evalProj.getName() + "-" + sourceSet.getName());
-            // Use the same groupId as the evalProj
-            if (Objects.toString(evalProj.getGroup()).isEmpty()) {
-              doError(evalProj, "Unable to publish MC-source set " + sourceSet.getName() + " due to no group being known for the project " + evalProj.getName() + ". \nTry `group='example'` in your build.gradle");
-            }
-            mavenPublication.setGroupId(evalProj.getGroup().toString());
-            // version is set implicitly
-
-            // and add all three jars as an artifact
-            mavenPublication.getArtifacts().artifact(grammarsJarArtifact);
-            mavenPublication.getArtifacts().artifact(jarArtifact);
-            mavenPublication.getArtifacts().artifact(sourcesJarArtifact);
-
-            // Next, provide the source set specific component (for the Gradle module system)
-            mavenPublication.from(component);
-
-            // The publication should not be considered when converting project dependencies to published metadata
-            // avoids:
-            // Publishing is not able to resolve a dependency on a project with multiple publications that have different coordinates
-            ((DefaultMavenPublication) mavenPublication).setAlias(true);
-          });
+          // First, check if the publication already exists
+          var pubOpt = publExt.getPublications()
+                  .matching(publication -> publication.getName().equals(sourceSet.getName())
+                          && publication instanceof MavenPublication).stream().findAny();
+          if (pubOpt.isPresent()) {
+            // If present, properly configure it
+            configureNonMainPublication(grammarsJarArtifact, sourceSet, component, evalProj, (MavenPublication) pubOpt.get(), jarArtifact, sourcesJarArtifact);
+          } else {
+            // Otherwise create it & configure it then
+            publExt.getPublications().create(sourceSet.getName(), MavenPublication.class, mavenPublication -> {
+              configureNonMainPublication(grammarsJarArtifact, sourceSet, component, evalProj, mavenPublication, jarArtifact, sourcesJarArtifact);
+            });
+          }
         });
       });
     });
+  }
+
+  protected void configureNonMainPublication(PublishArtifact grammarsJarArtifact, SourceSet sourceSet, AdhocComponentWithVariants component, Project evalProj, MavenPublication mavenPublication, PublishArtifact jarArtifact, PublishArtifact sourcesJarArtifact) {
+    // And append the source set name as an appendix to the artifact id
+    mavenPublication.setArtifactId(evalProj.getName() + "-" + sourceSet.getName());
+    // Use the same groupId as the evalProj
+    if (Objects.toString(evalProj.getGroup()).isEmpty()) {
+      doError(evalProj, "Unable to publish MC-source set " + sourceSet.getName() + " due to no group being known for the project " + evalProj.getName() + ". \nTry `group='example'` in your build.gradle");
+    }
+    mavenPublication.setGroupId(evalProj.getGroup().toString());
+    // version is set implicitly
+
+    // and add all three jars as an artifact
+    mavenPublication.getArtifacts().artifact(grammarsJarArtifact);
+    mavenPublication.getArtifacts().artifact(jarArtifact);
+    mavenPublication.getArtifacts().artifact(sourcesJarArtifact);
+
+    // Next, provide the source set specific component (for the Gradle module system)
+    mavenPublication.from(component);
+
+    // The publication should not be considered when converting project dependencies to published metadata
+    // avoids:
+    // Publishing is not able to resolve a dependency on a project with multiple publications that have different coordinates
+    ((DefaultMavenPublication) mavenPublication).setAlias(true);
   }
 
   /**

--- a/monticore-generator/src/main/java/de/monticore/gradle/dependencies/MCPublishingPlugin.java
+++ b/monticore-generator/src/main/java/de/monticore/gradle/dependencies/MCPublishingPlugin.java
@@ -187,10 +187,6 @@ public class MCPublishingPlugin implements Plugin<Project> {
    * Create the Jar tasks for non-main source sets and configure them for publication
    */
   protected void setupNonMainPublish(PublishArtifact grammarsJarArtifact, Project project, SourceSet sourceSet, AdhocComponentWithVariants component) {
-    if (Objects.toString(project.getGroup()).isEmpty()) {
-      doError(project, "Unable to publish MC-source set " + sourceSet.getName() + " due to no group being set");
-    }
-
     // Similar to the java feature, we a source set specific Jar and sourcesJar task
     TaskProvider<Jar> jarTask = createJarTask(sourceSet, project);
     TaskProvider<Jar> sourcesJarTask = createSourcesJarTask(sourceSet, project);
@@ -216,34 +212,38 @@ public class MCPublishingPlugin implements Plugin<Project> {
     component.addVariantsFromConfiguration(compileClasspathConfig, new JavaConfigurationVariantMapping("compile", false));
     compileClasspathConfig.getOutgoing().getArtifacts().add(jarArtifact);
 
-    // Ensure maven-publish is applied
-    @Nullable PublishingExtension publExt = project.getExtensions().findByType(PublishingExtension.class);
-    if (publExt == null) {
-      doError(project, "Publishing using the MontiCore Generator plugin requires the maven-publish plugin to be applied first!");
-      return;
-    }
+    // We have to use afterEvaluate due to accessing the Project#getGroup() value
+    project.afterEvaluate(evalProj -> {
+      // Only register the publication when the maven-publish plugin is loaded
+      evalProj.getPluginManager().withPlugin("maven-publish", mavenPublishPlugin -> {
+        evalProj.getExtensions().configure(PublishingExtension.class, publExt -> {
+          // Set up a Maven publication for non-main source sets
+          publExt.getPublications().create(sourceSet.getName(), MavenPublication.class, mavenPublication -> {
+            // And append the source set name as an appendix to the artifact id
+            mavenPublication.setArtifactId(evalProj.getName() + "-" + sourceSet.getName());
+            // Use the same groupId as the evalProj
+            if (Objects.toString(evalProj.getGroup()).isEmpty()) {
+              doError(evalProj, "Unable to publish MC-source set " + sourceSet.getName() + " due to no group being known for the project " + evalProj.getName() + ". \nTry `group='example'` in your build.gradle");
+            }
+            mavenPublication.setGroupId(evalProj.getGroup().toString());
+            // version is set implicitly
 
-    // Set up a Maven publication for non-main source sets
-    publExt
-            .getPublications().create(sourceSet.getName(), MavenPublication.class, mavenPublication -> {
-              // And append the source set name as an appendix to the artifact id
-              mavenPublication.setArtifactId(project.getName() + "-" + sourceSet.getName());
-              mavenPublication.setGroupId(project.getGroup().toString());
-              // version is set implicitly
+            // and add all three jars as an artifact
+            mavenPublication.getArtifacts().artifact(grammarsJarArtifact);
+            mavenPublication.getArtifacts().artifact(jarArtifact);
+            mavenPublication.getArtifacts().artifact(sourcesJarArtifact);
 
-              // and add all three jars as an artifact
-              mavenPublication.getArtifacts().artifact(grammarsJarArtifact);
-              mavenPublication.getArtifacts().artifact(jarArtifact);
-              mavenPublication.getArtifacts().artifact(sourcesJarArtifact);
+            // Next, provide the source set specific component (for the Gradle module system)
+            mavenPublication.from(component);
 
-              // Next, provide the source set specific component (for the Gradle module system)
-              mavenPublication.from(component);
-
-              // The publication should not be considered when converting project dependencies to published metadata
-              // avoids:
-              // Publishing is not able to resolve a dependency on a project with multiple publications that have different coordinates
-              ((DefaultMavenPublication) mavenPublication).setAlias(true);
-            });
+            // The publication should not be considered when converting project dependencies to published metadata
+            // avoids:
+            // Publishing is not able to resolve a dependency on a project with multiple publications that have different coordinates
+            ((DefaultMavenPublication) mavenPublication).setAlias(true);
+          });
+        });
+      });
+    });
   }
 
   /**

--- a/monticore-grammar/build.gradle
+++ b/monticore-grammar/build.gradle
@@ -649,7 +649,7 @@ if (("true").equals(getProperty('genTR'))) {
 
   publishing {
     publications {
-      "trafo" {
+      "trafo" (MavenPublication) {
         groupId = "de.monticore" // do not use the fake "de.mc" group, which was set during the plugin init phase
       }
     }


### PR DESCRIPTION
Project#getGroup() is only available after the project has been evaluated.