### PR TITLE
Fix astextends combination with overriden productions

### DIFF
--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_parser/ParserForSuperDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_parser/ParserForSuperDecorator.java
@@ -21,6 +21,7 @@ import de.monticore.generating.templateengine.GlobalExtensionManagement;
 import de.monticore.generating.templateengine.StringHookPoint;
 import de.monticore.generating.templateengine.TemplateHookPoint;
 import de.monticore.symbols.basicsymbols._symboltable.DiagramSymbol;
+import de.monticore.symbols.basicsymbols._symboltable.TypeSymbol;
 import de.monticore.types.check.SymTypeExpression;
 import de.monticore.types.mcbasictypes.MCBasicTypesMill;
 import de.monticore.types.mcbasictypes._ast.ASTMCQualifiedName;
@@ -222,8 +223,12 @@ public class ParserForSuperDecorator extends AbstractDecorator {
     firstClasses.addAll(l.values());
   }
 
-  protected boolean overrides(CDTypeSymbol first, CDTypeSymbol second){
-     return getSuperTypesTransitive(first).stream().map(CDTypeSymbol::getFullName).collect(Collectors.toList()).contains(second.getFullName());
+  protected boolean overrides(CDTypeSymbol first, CDTypeSymbol second) {
+    if (first.equals(second)) {
+      // Speed up check for default case
+      return true;
+    }
+    return getSuperTypesTransitive(first).contains(second.getFullName());
   }
 
   protected List<ASTCDMethod> getOverriddenMethods(CDTypeSymbol type, DiagramSymbol grammar, Collection<CDTypeSymbol> firstClasses){
@@ -300,26 +305,37 @@ public class ParserForSuperDecorator extends AbstractDecorator {
     return methods;
   }
 
-  protected List<CDTypeSymbol> getSuperTypesTransitive(CDTypeSymbol startType) {
-    List<CDTypeSymbol> superTypes = new ArrayList();
-    if (startType.isPresentSuperClass()) {
-      SymTypeExpression ste = startType.getSuperClass();
-      CDTypeSymbolSurrogate s = new CDTypeSymbolSurrogate(ste.getTypeInfo().getFullName());
-      s.setEnclosingScope(ste.getTypeInfo().getEnclosingScope());
-      superTypes.add(s.lazyLoadDelegate());
-      superTypes.addAll(getSuperTypesTransitive(s.lazyLoadDelegate()));
-    }
-
-    for (SymTypeExpression ste : startType.getSuperTypesList()) {
-      CDTypeSymbolSurrogate tss = new CDTypeSymbolSurrogate(ste.getTypeInfo().getFullName());
-      tss.setEnclosingScope(ste.getTypeInfo().getEnclosingScope());
-      CDTypeSymbol i = tss.lazyLoadDelegate();
-      superTypes.add(i);
-      superTypes.addAll(getSuperTypesTransitive(i));
-    }
-    return superTypes;
+  protected Set<String> getSuperTypesTransitive(CDTypeSymbol startType) {
+    var ret = new HashSet<String>();
+    getSuperTypesTransitive(startType, ret);
+    return ret;
   }
 
+  protected void getSuperTypesTransitive(CDTypeSymbol cdTypeSymbol, Set<String> superTypes) {
+    if (superTypes.contains(cdTypeSymbol.getFullName())) return;
+    superTypes.add(cdTypeSymbol.getFullName());
+    var types = cdTypeSymbol.getEnclosingScope().resolveCDTypeMany(cdTypeSymbol.getFullName());
+    getSuperTypesTransitive(types, superTypes);
+  }
 
+  protected void getSuperTypesTransitive(TypeSymbol typeSymbol, Set<String> superTypes) {
+    if (superTypes.contains(typeSymbol.getFullName())) return;
+    superTypes.add(typeSymbol.getFullName());
+    var types = ((ICDBasisScope) typeSymbol).getEnclosingScope().resolveCDTypeMany(typeSymbol.getFullName());
+    getSuperTypesTransitive(types, superTypes);
+  }
+
+  protected void getSuperTypesTransitive(List<CDTypeSymbol> resolvedTypes, Set<String> superTypes) {
+    // if types is empty: CD Symbol not loaded (e.g., external type?) => unable to continue to load supertypes
+    if (!resolvedTypes.isEmpty()) {
+      var startTypeSymbol = resolvedTypes.get(0); // we expect to only find 1 symbol
+      if (startTypeSymbol.isPresentSuperClass()) {
+        getSuperTypesTransitive(startTypeSymbol.getSuperClass().getTypeInfo(), superTypes);
+      }
+      for (SymTypeExpression ste : startTypeSymbol.getSuperTypesList()) {
+        getSuperTypesTransitive(ste.getTypeInfo(), superTypes);
+      }
+    }
+  }
 
 }

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_parser/ParserForSuperDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_parser/ParserForSuperDecorator.java
@@ -226,7 +226,7 @@ public class ParserForSuperDecorator extends AbstractDecorator {
   protected boolean overrides(CDTypeSymbol first, CDTypeSymbol second) {
     if (first.equals(second)) {
       // Speed up check for default case
-      return true;
+      return false;
     }
     return getSuperTypesTransitive(first).contains(second.getFullName());
   }

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_parser/ParserForSuperDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_parser/ParserForSuperDecorator.java
@@ -321,7 +321,7 @@ public class ParserForSuperDecorator extends AbstractDecorator {
   protected void getSuperTypesTransitive(TypeSymbol typeSymbol, Set<String> superTypes) {
     if (superTypes.contains(typeSymbol.getFullName())) return;
     superTypes.add(typeSymbol.getFullName());
-    var types = ((ICDBasisScope) typeSymbol).getEnclosingScope().resolveCDTypeMany(typeSymbol.getFullName());
+    var types = ((ICDBasisScope) typeSymbol.getEnclosingScope()).resolveCDTypeMany(typeSymbol.getFullName());
     getSuperTypesTransitive(types, superTypes);
   }
 

--- a/monticore-generator/src/test/java/de/monticore/MontiCoreScriptTest.java
+++ b/monticore-generator/src/test/java/de/monticore/MontiCoreScriptTest.java
@@ -23,6 +23,7 @@ import de.monticore.grammar.grammar_withconcepts.Grammar_WithConceptsMill;
 import de.monticore.grammar.grammar_withconcepts._symboltable.Grammar_WithConceptsGlobalScope;
 import de.monticore.grammar.grammar_withconcepts._symboltable.IGrammar_WithConceptsGlobalScope;
 import de.monticore.io.paths.MCPath;
+import de.monticore.runtime.junit.MCAssertions;
 import de.se_rwth.commons.logging.Log;
 import de.se_rwth.commons.logging.LogStub;
 import org.apache.commons.cli.*;
@@ -107,7 +108,7 @@ public class MontiCoreScriptTest {
     Assertions.assertNotNull(grammar);
     Assertions.assertEquals("Statechart", grammar.getName());
   
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   /**
@@ -126,7 +127,7 @@ public class MontiCoreScriptTest {
             new MCPath(), f);
     f.delete();
   
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -140,7 +141,7 @@ public class MontiCoreScriptTest {
     Assertions.assertNotNull(cdCompilationUnit.getCDDefinition());
     Assertions.assertEquals("Statechart", cdCompilationUnit.getCDDefinition().getName());
   
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -154,7 +155,7 @@ public class MontiCoreScriptTest {
     Assertions.assertNotNull(cdCompilationUnit.getCDDefinition());
     Assertions.assertEquals("Statechart", cdCompilationUnit.getCDDefinition().getName());
   
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -193,7 +194,7 @@ public class MontiCoreScriptTest {
       }
     }
   
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -209,7 +210,7 @@ public class MontiCoreScriptTest {
       Assertions.fail();
     }
   
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   static String[] templateArgs = {"-" + GRAMMAR,
@@ -232,7 +233,7 @@ public class MontiCoreScriptTest {
       Assertions.fail();
     }
   
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   static String[] subsubgrammarArgs = {"-" + GRAMMAR,
@@ -244,18 +245,14 @@ public class MontiCoreScriptTest {
   public void testDefaultScriptSubsubgrammarArgs() {
     Log.getFindings().clear();
     testDefaultScript(subsubgrammarArgs);
-    Assertions.assertEquals(0, Log.getErrorCount());
-  
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   @Test
   public void testDefaultScriptSubsubgrammarArgs_EMF() {
     Log.getFindings().clear();
     testDefaultScriptWithEmf(subsubgrammarArgs);
-    Assertions.assertEquals(0, Log.getErrorCount());
-  
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   static String[] inheritedgrammarArgs = {"-" + GRAMMAR,
@@ -289,18 +286,14 @@ public class MontiCoreScriptTest {
   public void testDefaultScriptSupersubgrammarArgs() {
     Log.getFindings().clear();
     testDefaultScript(supersubgrammarArgs);
-    Assertions.assertEquals(0, Log.getErrorCount());
-  
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   @Test
   public void testDefaultScriptSupersubgrammarArgs_EMF() {
     Log.getFindings().clear();
     testDefaultScriptWithEmf(supersubgrammarArgs);
-    Assertions.assertEquals(0, Log.getErrorCount());
-  
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   private void testDefaultScript(String[] args) {
@@ -318,7 +311,6 @@ public class MontiCoreScriptTest {
     // Reporting is enabled in the monticore_standard.groovy script but needs to be disabled for other tests
     // because Reporting is static directly disable it again here
     Reporting.off();
-    Assertions.assertTrue(!false);
   }
 
   private void testDefaultScriptWithEmf(String[] args) {
@@ -360,8 +352,8 @@ public class MontiCoreScriptTest {
     Assertions.assertEquals("StatechartSymbols", symbolCDOfParsedGrammar.getCDDefinition().getName());
     // no symbol defined
     Assertions.assertEquals(0, symbolCDOfParsedGrammar.getCDDefinition().getCDClassesList().size());
-  
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -385,8 +377,8 @@ public class MontiCoreScriptTest {
     Assertions.assertEquals("StatechartScope", scopeCDOfParsedGrammar.getCDDefinition().getName());
     Assertions.assertEquals(1, scopeCDOfParsedGrammar.getCDDefinition().getCDClassesList().size());
     Assertions.assertEquals("Statechart", scopeCDOfParsedGrammar.getCDDefinition().getCDClassesList().get(0).getName());
-  
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -415,8 +407,8 @@ public class MontiCoreScriptTest {
     assertDeepEquals("java.util.List<de.monticore.statechart.Statechart.ASTState>", listSuffixStateChartClass.getCDAttributeList().get(1).getMCType());
     // attribute with 's' at the end now
     Assertions.assertEquals("states", listSuffixStateChartClass.getCDAttributeList().get(1).getName());
-  
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -456,8 +448,8 @@ public class MontiCoreScriptTest {
     Assertions.assertEquals("ICommonStatechartSymbol", symbolPackageCD.getCDDefinition().getCDInterfacesList().get(index++).getName());
     Assertions.assertEquals("IStatechartGlobalScope", symbolPackageCD.getCDDefinition().getCDInterfacesList().get(index++).getName());
     Assertions.assertEquals("IStatechartArtifactScope", symbolPackageCD.getCDDefinition().getCDInterfacesList().get(index++).getName());
-  
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -484,8 +476,8 @@ public class MontiCoreScriptTest {
     Assertions.assertEquals("StatechartTraverser", visitorPackageCD.getCDDefinition().getCDInterfacesList().get(0).getName());
     Assertions.assertEquals("StatechartVisitor2", visitorPackageCD.getCDDefinition().getCDInterfacesList().get(1).getName());
     Assertions.assertEquals("StatechartHandler", visitorPackageCD.getCDDefinition().getCDInterfacesList().get(2).getName());
-  
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -521,7 +513,7 @@ public class MontiCoreScriptTest {
     Assertions.assertEquals("StatechartASTClassbodyExtCoCo", cocoPackageCD.getCDDefinition().getCDInterfacesList().get(11).getName());
     Assertions.assertEquals("StatechartASTStatechartNodeCoCo", cocoPackageCD.getCDDefinition().getCDInterfacesList().get(12).getName());
   
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -568,7 +560,7 @@ public class MontiCoreScriptTest {
     Assertions.assertEquals(1, astPackageCD.getCDDefinition().getCDEnumsList().size());
     Assertions.assertEquals("StatechartLiterals", astPackageCD.getCDDefinition().getCDEnumsList().get(0).getName());
   
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -617,7 +609,7 @@ public class MontiCoreScriptTest {
     Assertions.assertEquals(1, astEmfPackageCD.getCDDefinition().getCDEnumsList().size());
     Assertions.assertEquals("StatechartLiterals", astEmfPackageCD.getCDDefinition().getCDEnumsList().get(0).getName());
   
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -642,7 +634,7 @@ public class MontiCoreScriptTest {
     Assertions.assertTrue(odPackage.getCDDefinition().getCDInterfacesList().isEmpty());
     Assertions.assertTrue(odPackage.getCDDefinition().getCDEnumsList().isEmpty());
   
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -670,7 +662,7 @@ public class MontiCoreScriptTest {
     Assertions.assertEquals("Statechart", decoratedCompilationUnit.getCDDefinition().getName());
     Assertions.assertEquals(1, millPackage.get().getCDElementList().size());
 
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -695,7 +687,7 @@ public class MontiCoreScriptTest {
     Assertions.assertTrue(decoratedCd.getCDDefinition().getCDInterfacesList().isEmpty());
     Assertions.assertTrue(decoratedCd.getCDDefinition().getCDEnumsList().isEmpty());
   
-    Assertions.assertTrue(Log.getFindings().isEmpty());
+    MCAssertions.assertNoFindings();
   }
 
   /**

--- a/monticore-generator/src/test/java/de/monticore/runtime/junit/MCAssertions.java
+++ b/monticore-generator/src/test/java/de/monticore/runtime/junit/MCAssertions.java
@@ -1,0 +1,63 @@
+package de.monticore.runtime.junit;
+
+import com.google.common.collect.Streams;
+import de.se_rwth.commons.logging.Finding;
+import de.se_rwth.commons.logging.Log;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.stream.Collectors;
+
+/**
+ * A copy of the MCAssertions class from the runtime test fixtures
+ */
+public class MCAssertions {
+  /**
+   * Asserts that no findings are present.
+   *
+   * @param message the message to fail with iff findings were found
+   */
+  public static void assertNoFindings(String message) {
+    if (!Log.getFindings().isEmpty()) {
+      failAndPrintFindings(message);
+    }
+  }
+
+  /**
+   * Asserts that no findings are present.
+   */
+  public static void assertNoFindings() {
+    assertNoFindings("Encountered Log-Findings while expecting none");
+  }
+
+
+  /**
+   * Fails a test with the given failure message.
+   * Additionally, Lists the state of Log-Findings.
+   * See Javadoc for {@link Assertions#fail(String, Throwable)}
+   * for an explanation of this method's generic return type V.
+   *
+   * @param message message to print
+   * @return nothing
+   */
+  public static <V> V failAndPrintFindings(String message) {
+    StringBuilder messageWithFindings = new StringBuilder();
+    if (!message.isBlank()) {
+      messageWithFindings.append(message);
+    } else {
+      messageWithFindings.append("Failed (no reason stated)");
+    }
+    messageWithFindings.append(System.lineSeparator());
+    if (Log.getFindings().isEmpty()) {
+      messageWithFindings.append("Got no Log-Findings.");
+    } else {
+      messageWithFindings.append("Got Log-Findings:");
+      messageWithFindings.append(System.lineSeparator());
+      messageWithFindings.append(Streams.mapWithIndex(
+                      Log.getFindings().stream().map(Finding::buildMsg),
+                      (str, index) -> "[" + index + "]" + str)
+              .collect(Collectors.joining(System.lineSeparator()))
+      );
+    }
+    return Assertions.fail(messageWithFindings.toString());
+  }
+}

--- a/monticore-generator/src/test/resources/de/monticore/inherited/Supergrammar.mc4
+++ b/monticore-generator/src/test/resources/de/monticore/inherited/Supergrammar.mc4
@@ -15,4 +15,8 @@ component grammar Supergrammar {
   K implements G = "OO";
   
   N;
+
+ ODName_Rep implements ITFODName    ;
+
+ interface ITFODName astextends de.monticore.ast.ASTNode; // any class not specified by a grammar
 }

--- a/monticore-generator/src/test/resources/de/monticore/inherited/sub/Subgrammar.mc4
+++ b/monticore-generator/src/test/resources/de/monticore/inherited/sub/Subgrammar.mc4
@@ -20,5 +20,8 @@ grammar Subgrammar extends de.monticore.inherited.Supergrammar {
 
   @Override
   N = X?;
+
+  @Override
+  ODName_Rep = "hello"  ;
  
 }

--- a/monticore-generator/src/test/resources/de/monticore/inherited/subsub/Subsubgrammar.mc4
+++ b/monticore-generator/src/test/resources/de/monticore/inherited/subsub/Subsubgrammar.mc4
@@ -12,5 +12,9 @@ grammar Subsubgrammar extends de.monticore.inherited.sub.Subgrammar {
   S = X*;
   
 //  X = Y "HH" J D;
+
+
+  @Override
+  ODName_Rep = "world"  ;
  
 }

--- a/monticore-grammar/src/main/java/de/monticore/grammar/cocos/OverridingInterfaceNTs.java
+++ b/monticore-grammar/src/main/java/de/monticore/grammar/cocos/OverridingInterfaceNTs.java
@@ -39,7 +39,7 @@ public class OverridingInterfaceNTs implements GrammarASTMCGrammarCoCo {
       for (MCGrammarSymbol s : grammarSymbols) {
         Optional<ProdSymbol> typeSymbol = s.getProd(p.getName());
         if (typeSymbol.isPresent() && typeSymbol.get().isIsInterface()) {
-          Log.error(String.format(ERROR_CODE + ERROR_MSG_FORMAT, typeSymbol.get().getName()));
+          Log.error(String.format(ERROR_CODE + ERROR_MSG_FORMAT, typeSymbol.get().getName()), p.get_SourcePositionStart());
         }
       }
     }


### PR DESCRIPTION
* Fix ParserForSuper resolving for astexternals (monticore/monticore#4768)
* Include test for the fix
* Start using the runtime testFixtures in generator tests (using a drop-in replacement) 