### PR TITLE
Prevent empty astrules in generated DSTLs

### DIFF
--- a/monticore-generator/src/main/java/de/monticore/dstlgen/grammartransformation/DSL2TransformationLanguageVisitor.java
+++ b/monticore-generator/src/main/java/de/monticore/dstlgen/grammartransformation/DSL2TransformationLanguageVisitor.java
@@ -323,7 +323,17 @@ public class DSL2TransformationLanguageVisitor implements
     Log.debug("Visiting ast rule " + srcNode.getType(), LOG);
     List<ASTASTRule> targetAstRuleList = tfLang.getASTRuleList();
     if (!("MCCompilationUnit").equals(srcNode.getType())) {
-      targetAstRuleList.add(astRuleFactory.createASTRule(srcNode, grammarSymbol));
+      ASTASTRule targetNode = astRuleFactory.createASTRule(srcNode, grammarSymbol);
+      
+      boolean hasSuperClass = !targetNode.isEmptyASTSuperClass();
+      boolean hasSuperInterface = !targetNode.isEmptyASTSuperInterface();
+      boolean hasGrammarMethods = !targetNode.isEmptyGrammarMethods();
+      boolean hasAdditionalAttributes = !targetNode.isEmptyAdditionalAttributes();
+      
+      // only create ASTRule if it has any influence
+      if (hasSuperClass || hasSuperInterface || hasGrammarMethods || hasAdditionalAttributes) {
+        targetAstRuleList.add(targetNode);
+      }
     }
   }
 

--- a/monticore-test/montitrans/test-dstl-gen/build.gradle
+++ b/monticore-test/montitrans/test-dstl-gen/build.gradle
@@ -158,6 +158,43 @@ tasks.register('generateUsingEmptyComponentGrammarTR', MCTask) {
   dependsOn generateEmptyComponentGrammarTR
 }
 
+tasks.register('generateODNameBasis', MCTask) {
+  grammar = file "$grammarsDir/mc/testcases/odname/ODNameBasis.mc4"
+  outputDir = file _outputDir
+  def uptoDate = incCheck("mc/testcases/odname/ODNameBasis.mc4")
+  outputs.upToDateWhen { uptoDate }
+}
+
+tasks.register('generateODNameReport', MCTask) {
+  grammar = file "$grammarsDir/mc/testcases/odname/ODNameReport.mc4"
+  outputDir = file _outputDir
+  def uptoDate = incCheck("mc/testcases/odname/ODNameReport.mc4")
+  outputs.upToDateWhen { uptoDate }
+  dependsOn generateODNameBasis
+}
+
+tasks.register('generateODNameBasisTR', MCTask) {
+  dependsOn generateODNameBasis
+  grammar = file "$_outputDir/mc/testcases/odname/tr/ODNameBasisTR.mc4"
+  outputDir = file _outputDir
+  modelPath += file grammarsDir
+  modelPath += file _outputDir
+  def uptoDate = incCheck("mc/testcases/odname/tr/ODNameBasisTR.mc4")
+  outputs.upToDateWhen { uptoDate }
+  isDSTL = true
+}
+
+tasks.register('generateODNameReportTR', MCTask) {
+  dependsOn generateODNameReport
+  grammar = file "$_outputDir/mc/testcases/odname/tr/ODNameReportTR.mc4"
+  outputDir = file _outputDir
+  modelPath += file grammarsDir
+  modelPath += file _outputDir
+  def uptoDate = incCheck("mc/testcases/odname/tr/ODNameReportTR.mc4")
+  outputs.upToDateWhen { uptoDate }
+  isDSTL = true
+}
+
 // The following explicit task dependencies are required in order to upgrade to Gradle 8+
 // They are not required when using the de.monticore.generator / MCGenTask
 tasks.withType(MCTask.class).configureEach {

--- a/monticore-test/montitrans/test-dstl-gen/src/main/grammars/mc/testcases/odname/ODNameBasis.mc4
+++ b/monticore-test/montitrans/test-dstl-gen/src/main/grammars/mc/testcases/odname/ODNameBasis.mc4
@@ -1,0 +1,8 @@
+/* (c) https://github.com/MontiCore/monticore */
+package mc.testcases.odname;
+
+component grammar ODNameBasis extends de.monticore.MCBasics {
+  interface ODValue;
+
+  ODName implements ODValue = Name;
+}

--- a/monticore-test/montitrans/test-dstl-gen/src/main/grammars/mc/testcases/odname/ODNameReport.mc4
+++ b/monticore-test/montitrans/test-dstl-gen/src/main/grammars/mc/testcases/odname/ODNameReport.mc4
@@ -1,0 +1,17 @@
+/* (c) https://github.com/MontiCore/monticore */
+package mc.testcases.odname;
+
+component grammar ODNameReport extends mc.testcases.odname.ODNameBasis {
+  token ODSpecialName = '@' Name;
+
+  @Override
+  ODName implements ODValue = Name | ODSpecialName;
+
+  astrule ODName =
+      method public String getName() {
+        if (isPresentName()) {
+          return this.name.get();
+        }
+        return "noname";
+       };
+}


### PR DESCRIPTION
A generated DSTL contains ASTRules mirroring the original grammar.
However, these ASTRules do NOT contain methods and also attributs only under certain conditions.
In many cases, this results in empty ASTRules in the DSTL, that have no impact and could be removed.

**Example:**
```
astrule ITFODName;
```

This pull requests adds checks for necessity befor adding an ASTRule to the DSTL.