### PR TITLE
Fix override annotations for generated dstl prods

### DIFF
--- a/monticore-generator/src/main/java/de/monticore/dstlgen/grammartransformation/DSL2TransformationLanguageVisitor.java
+++ b/monticore-generator/src/main/java/de/monticore/dstlgen/grammartransformation/DSL2TransformationLanguageVisitor.java
@@ -357,6 +357,7 @@ public class DSL2TransformationLanguageVisitor implements
   }
   
   protected void addASTClassProdAnnotations(ASTClassProd prod, boolean override) {
+    // Add @Override annotation to the production if needed
     if (override) {
       prod.addGrammarAnnotation(productionFactory.createOverrideAnnotation());
     }

--- a/monticore-generator/src/main/java/de/monticore/dstlgen/grammartransformation/DSL2TransformationLanguageVisitor.java
+++ b/monticore-generator/src/main/java/de/monticore/dstlgen/grammartransformation/DSL2TransformationLanguageVisitor.java
@@ -10,7 +10,6 @@ import de.monticore.grammar.grammar._ast.*;
 import de.monticore.grammar.grammar._symboltable.MCGrammarSymbol;
 import de.monticore.grammar.grammar._symboltable.ProdSymbol;
 import de.monticore.grammar.grammar._visitor.GrammarVisitor2;
-import de.monticore.symboltable.modifiers.AccessModifier;
 import de.se_rwth.commons.Splitters;
 import de.se_rwth.commons.logging.Log;
 
@@ -237,7 +236,7 @@ public class DSL2TransformationLanguageVisitor implements
         tfLang.getInterfaceProdList().add(productionFactory.createInterfaceProd(srcNode, grammar_depth, isLeftRecursive));
       }
 
-      ASTClassProd p = productionFactory.createProd(srcNode, LIST,superExternal, isLeftRecursive);
+      ASTClassProd p = productionFactory.createProd(srcNode, LIST, superExternal, isLeftRecursive);
       if (!isEmpty){
         productionFactory
                 .addInterfaces(srcNode.getSuperRuleList(), p);
@@ -246,6 +245,7 @@ public class DSL2TransformationLanguageVisitor implements
       } else {
         p.add_PreComment(new Comment(" /*Skipping supers due to empty prod*/ "));
       }
+      addASTClassProdAnnotations(p, overridden);
       targetClassProdList.add(0, p);
 
       p = productionFactory.createProd(srcNode, OPTIONAL, superExternal, isLeftRecursive);
@@ -257,6 +257,7 @@ public class DSL2TransformationLanguageVisitor implements
       } else {
         p.add_PreComment(new Comment(" /*Skipping supers due to " + (isEmpty ? "empty prod " : "") + (isLeftRecursive ? "left recursiveness " : "") + " */ "));
       }
+      addASTClassProdAnnotations(p, overridden);
       targetClassProdList.add(0, p);
 
       p = productionFactory.createProd(srcNode, NEGATION, superExternal, isLeftRecursive);
@@ -268,10 +269,11 @@ public class DSL2TransformationLanguageVisitor implements
       }else{
         p.add_PreComment(new Comment(" /*Skipping supers due to " + (isEmpty ? "empty prod " : "") + (isLeftRecursive ? "left recursiveness " : "") + " */ "));
       }
+      addASTClassProdAnnotations(p, overridden);
       targetClassProdList.add(0, p);
 
       p =  productionFactory.createPatternProd(srcNode,grammarSymbol, superExternal, isLeftRecursive, isEmpty);
-
+      addASTClassProdAnnotations(p, overridden);
       targetClassProdList.add(0, p);
 
       p = productionFactory.createReplacementProd(srcNode, superExternal);
@@ -281,6 +283,7 @@ public class DSL2TransformationLanguageVisitor implements
       }else{
         p.add_PreComment(new Comment(" /*Skipping supers due to " + (isEmpty ? "empty prod " : "") + (isLeftRecursive ? "left recursiveness " : "") + " */ "));
       }
+      addASTClassProdAnnotations(p, overridden);
       targetClassProdList.add(0, p);
 
       targetAstRuleList.add(astRuleFactory.createAstProd(srcNode, LIST, overridden, grammarSymbol));
@@ -349,6 +352,12 @@ public class DSL2TransformationLanguageVisitor implements
 
   public ASTMCGrammar getTfLang() {
     return tfLang;
+  }
+  
+  protected void addASTClassProdAnnotations(ASTClassProd prod, boolean override) {
+    if (override) {
+      prod.addGrammarAnnotation(productionFactory.createOverrideAnnotation());
+    }
   }
 
 }

--- a/monticore-generator/src/main/java/de/monticore/dstlgen/grammartransformation/DSL2TransformationLanguageVisitor.java
+++ b/monticore-generator/src/main/java/de/monticore/dstlgen/grammartransformation/DSL2TransformationLanguageVisitor.java
@@ -237,36 +237,21 @@ public class DSL2TransformationLanguageVisitor implements
       }
 
       ASTClassProd p = productionFactory.createProd(srcNode, LIST, superExternal, isLeftRecursive);
-      if (!isEmpty){
-        productionFactory
-                .addInterfaces(srcNode.getSuperRuleList(), p);
-        productionFactory.addInterfaces(
-                srcNode.getSuperInterfaceRuleList(), p);
-      } else {
+      if (!addASTClassProdInterfaces(srcNode, p, LIST, isLeftRecursive, isEmpty)) {
         p.add_PreComment(new Comment(" /*Skipping supers due to empty prod*/ "));
       }
       addASTClassProdAnnotations(p, overridden);
       targetClassProdList.add(0, p);
 
       p = productionFactory.createProd(srcNode, OPTIONAL, superExternal, isLeftRecursive);
-      if (!isLeftRecursive && !isEmpty) {
-        productionFactory
-                .addInterfaces(srcNode.getSuperRuleList(), p);
-        productionFactory.addInterfaces(
-                srcNode.getSuperInterfaceRuleList(), p);
-      } else {
+      if (!addASTClassProdInterfaces(srcNode, p, OPTIONAL, isLeftRecursive, isEmpty)) {
         p.add_PreComment(new Comment(" /*Skipping supers due to " + (isEmpty ? "empty prod " : "") + (isLeftRecursive ? "left recursiveness " : "") + " */ "));
       }
       addASTClassProdAnnotations(p, overridden);
       targetClassProdList.add(0, p);
 
       p = productionFactory.createProd(srcNode, NEGATION, superExternal, isLeftRecursive);
-      if (!isLeftRecursive && !isEmpty) {
-        productionFactory
-                .addInterfaces(srcNode.getSuperRuleList(), p);
-        productionFactory.addInterfaces(
-                srcNode.getSuperInterfaceRuleList(), p);
-      }else{
+      if (!addASTClassProdInterfaces(srcNode, p, NEGATION, isLeftRecursive, isEmpty)) {
         p.add_PreComment(new Comment(" /*Skipping supers due to " + (isEmpty ? "empty prod " : "") + (isLeftRecursive ? "left recursiveness " : "") + " */ "));
       }
       addASTClassProdAnnotations(p, overridden);
@@ -277,10 +262,7 @@ public class DSL2TransformationLanguageVisitor implements
       targetClassProdList.add(0, p);
 
       p = productionFactory.createReplacementProd(srcNode, superExternal);
-      if (!isLeftRecursive && !isEmpty) {
-        productionFactory.addInterfaces(srcNode.getSuperRuleList(),p);
-        productionFactory.addInterfaces(srcNode.getSuperInterfaceRuleList(),p);
-      }else{
+      if (!addASTClassProdInterfaces(srcNode, p, REPLACEMENT, isLeftRecursive, isEmpty)) {
         p.add_PreComment(new Comment(" /*Skipping supers due to " + (isEmpty ? "empty prod " : "") + (isLeftRecursive ? "left recursiveness " : "") + " */ "));
       }
       addASTClassProdAnnotations(p, overridden);
@@ -352,6 +334,26 @@ public class DSL2TransformationLanguageVisitor implements
 
   public ASTMCGrammar getTfLang() {
     return tfLang;
+  }
+  
+  protected boolean addASTClassProdInterfaces(ASTClassProd srcNode, ASTClassProd prod,
+      ProductionType productionType, boolean isLeftRecursive, boolean isEmpty) {
+    if (productionType == LIST) {
+      if (isEmpty) {
+        return false;
+      }
+      productionFactory.addInterfaces(srcNode.getSuperRuleList(), prod);
+      productionFactory.addInterfaces(srcNode.getSuperInterfaceRuleList(), prod);
+    }
+    else if (productionType == OPTIONAL || productionType == NEGATION
+        || productionType == REPLACEMENT) {
+      if (isLeftRecursive || isEmpty) {
+        return false;
+      }
+      productionFactory.addInterfaces(srcNode.getSuperRuleList(), prod);
+      productionFactory.addInterfaces(srcNode.getSuperInterfaceRuleList(), prod);
+    }
+    return true;
   }
   
   protected void addASTClassProdAnnotations(ASTClassProd prod, boolean override) {

--- a/monticore-generator/src/main/java/de/monticore/dstlgen/grammartransformation/ProductionFactory.java
+++ b/monticore-generator/src/main/java/de/monticore/dstlgen/grammartransformation/ProductionFactory.java
@@ -797,5 +797,13 @@ public class ProductionFactory {
               .build());
     }
   }
+  
+  /**
+   * Create a new @Override annotation
+   * @return ASTGrammarAnnotation with override property
+   */
+  protected ASTGrammarAnnotation createOverrideAnnotation() {
+    return GrammarMill.grammarAnnotationBuilder().setOverride(true).build();
+  }
 
 }

--- a/monticore-generator/src/main/java/de/monticore/dstlgen/util/DSTLPrettyPrinter.java
+++ b/monticore-generator/src/main/java/de/monticore/dstlgen/util/DSTLPrettyPrinter.java
@@ -29,56 +29,50 @@ public class DSTLPrettyPrinter extends GrammarPrettyPrinter {
    */
   @Override
   public void handle(ASTClassProd a) {
+    CommentPrettyPrinter.printPreComments(a, getPrinter());
     
-      
-      CommentPrettyPrinter.printPreComments(a, getPrinter());
-      
-      getPrinter().print(a.getName());
-      
-      if (!a.getSuperRuleList().isEmpty()) {
-        getPrinter().print(" extends ");
-        printList(a.getSuperRuleList().iterator(), ", ");
-      }
-      
-      if (!a.getSuperInterfaceRuleList().isEmpty()) {
-        getPrinter().print(" implements ");
-        printList(a.getSuperInterfaceRuleList().iterator(), ", ");
-      }
-      
-      if (!a.getASTSuperClassList().isEmpty()) {
-        getPrinter().print(" astextends ");
-        printList(a.getASTSuperClassList().iterator(), "");
-      }
-      
-      if (!a.getASTSuperInterfaceList().isEmpty()) {
-        getPrinter().print(" astimplements ");
-        printList(a.getASTSuperInterfaceList().iterator(), ", ");
-      }
-      
-      if (a.isPresentAction()) {
-        print(" {");
-        getPrinter().println();
-        getPrinter().indent();
-        a.getAction().accept(getTraverser());
-        getPrinter().unindent();
-        print("}");
-      }
-      
-      if (!a.getAltList().isEmpty()) {
-        println(" =");
-        
-        getPrinter().indent();
-        printList(a.getAltList().iterator(), " | ");
-      }
-      println(";");
-      
-      CommentPrettyPrinter.printPostComments(a, getPrinter());
-      getPrinter().unindent();
-      getPrinter().println();
     printList(a.iteratorGrammarAnnotations(), " ");
     getPrinter().println();
     getPrinter().print(a.getName());
     getPrinter().print(" ");
+    
+    if (!a.isEmptySuperRule()) {
+      getPrinter().print("extends ");
+      printList(a.iteratorSuperRule(), ", ");
+    }
+    if (!a.isEmptySuperInterfaceRule()) {
+      getPrinter().print("implements ");
+      printList(a.iteratorSuperInterfaceRule(), ", ");
+    }
+    if (!a.isEmptyASTSuperClass()) {
+      getPrinter().print("astextends ");
+      printList(a.iteratorASTSuperClass(), ", ");
+    }
+    if (!a.isEmptyASTSuperInterface()) {
+      getPrinter().print("astimplements ");
+      printList(a.iteratorASTSuperInterface(), ", ");
+    }
+    
+    if (a.isPresentAction()) {
+      getPrinter().print("{");
+      getPrinter().println();
+      getPrinter().indent();
+      a.getAction().accept(getTraverser());
+      getPrinter().unindent();
+      getPrinter().print("} ");
+    }
+    
+    if (!a.isEmptyAlts()) {
+      getPrinter().print("=");
+      getPrinter().println();
+      getPrinter().indent();
+      printList(a.iteratorAlts(), "| ");
+    }
+    getPrinter().println(";");
+    
+    CommentPrettyPrinter.printPostComments(a, getPrinter());
+    getPrinter().unindent();
+    getPrinter().println();
   }
 
   @Override
@@ -96,60 +90,60 @@ public class DSTLPrettyPrinter extends GrammarPrettyPrinter {
 //      print("*");
 //    }
     if (a.isPresentCard() && a.getCard().isPresentMin()) {
-      print(" min = " + a.getCard().getMin());
+      getPrinter().print(" min = " + a.getCard().getMin());
     }
     if (a.isPresentCard() && a.getCard().isPresentMax()) {
-      print(" max = " + a.getCard().getMax());
+      getPrinter().print(" max = " + a.getCard().getMax());
     }
-    println();
+    getPrinter().println();
   }
 
   @Override
   public void handle(ASTLexProd a) {
     if (a.isFragment()) {
-      this.print("fragment ");
+      getPrinter().print("fragment ");
     }
     
-    CommentPrettyPrinter.printPreComments(a, this.getPrinter());
-    this.print("token ");
-    this.println(a.getName());
-    this.getPrinter().indent();
+    CommentPrettyPrinter.printPreComments(a, getPrinter());
+    getPrinter().print("token ");
+    getPrinter().println(a.getName());
+    getPrinter().indent();
     if (a.isPresentLexOption()) {
       a.getLexOption().accept(this.getTraverser());
     }
     
     if (a.isPresentInitAction()) {
-      this.print(" {");
-      this.getPrinter().println();
-      this.getPrinter().indent();
+      getPrinter().print(" {");
+      getPrinter().println();
+      getPrinter().indent();
       a.getInitAction().accept(this.getTraverser());
-      this.getPrinter().unindent();
-      this.print("}");
+      getPrinter().unindent();
+      getPrinter().print("}");
     }
     
-    this.getPrinter().print("=");
-    this.printList(a.getAltList().iterator(), "|");
+    getPrinter().print("=");
+    printList(a.getAltList().iterator(), "|");
     if (a.isPresentVariable() || a.isPresentEndAction()) {
-      this.getPrinter().print(" : ");
+      getPrinter().print(" : ");
       if (a.isPresentEndAction()) {
-        this.getPrinter().print(" { ");
+        getPrinter().print(" { ");
         a.getEndAction().accept(getTraverser());
-        this.getPrinter().print(" } ");
+        getPrinter().print(" } ");
       }
       if (a.isPresentVariable()) {
-        this.getPrinter().print(a.getVariable());
+        getPrinter().print(a.getVariable());
         if (!a.getTypeList().isEmpty()) {
-          this.getPrinter().print("->");
-          this.getPrinter().print(Names.getQualifiedName(a.getTypeList()));
+          getPrinter().print("->");
+          getPrinter().print(Names.getQualifiedName(a.getTypeList()));
           if (a.isPresentBlock() || a.isPresentEndAction()) {
-            this.getPrinter().print(":");
+            getPrinter().print(":");
             if (a.isPresentEndAction()) {
-              this.print(" {");
-              this.getPrinter().println();
-              this.getPrinter().indent();
+              getPrinter().print(" {");
+              getPrinter().println();
+              getPrinter().indent();
               a.getEndAction().accept(this.getTraverser());
-              this.getPrinter().unindent();
-              this.print("}");
+              getPrinter().unindent();
+              getPrinter().print("}");
             }
 
             if (a.isPresentBlock()) {
@@ -160,23 +154,10 @@ public class DSTLPrettyPrinter extends GrammarPrettyPrinter {
       }
     }
     
-    this.print(";");
-    CommentPrettyPrinter.printPostComments(a, this.getPrinter());
-    this.println();
-    this.getPrinter().unindent();
-    this.println();
+    getPrinter().print(";");
+    CommentPrettyPrinter.printPostComments(a, getPrinter());
+    getPrinter().println();
+    getPrinter().unindent();
+    getPrinter().println();
   }
-
-  protected void print(String o) {
-    getPrinter().print(o);
-  }
-
-  protected void println(String o) {
-    this.getPrinter().println(o);
-  }
-
-  protected void println() {
-    this.getPrinter().println();
-  }
-
 }

--- a/monticore-generator/src/main/java/de/monticore/dstlgen/util/DSTLPrettyPrinter.java
+++ b/monticore-generator/src/main/java/de/monticore/dstlgen/util/DSTLPrettyPrinter.java
@@ -75,6 +75,10 @@ public class DSTLPrettyPrinter extends GrammarPrettyPrinter {
       CommentPrettyPrinter.printPostComments(a, getPrinter());
       getPrinter().unindent();
       getPrinter().println();
+    printList(a.iteratorGrammarAnnotations(), " ");
+    getPrinter().println();
+    getPrinter().print(a.getName());
+    getPrinter().print(" ");
   }
 
   @Override


### PR DESCRIPTION
This Pull Request adds `@Override` annotations for generated DSTLs in case of the generation of the typical TF production rules for a non-terminal that is overridden (4762).

**Example**
```
grammar X {
  A = Name;
}

grammar Y extends X {
  @Override
  A = Name | Digits;
}
```

The generated DSTLs will look like the following:
```
grammar XTF {
  interface ITFA;
  A_Neg implements ITFA ... = ...
  ...
}

grammar YTF extends XTF {
  A_Neg implements ITFA ... = ...
  ...
}
```

Due to the missing `@Override` annotation at the `A_Neg` non-terminal, the two generated `ASTA_Neg` (for grammar `XTF` and grammar `YTF`) are independent. Instead, the `ASTA_Neg` of `YTF` should extend `ASTA_Neg` of `XTF`.
```
grammar YTF extends XTF {
  @Override
  A_Neg implements ITFA ... = ...
  ...
}
```