### PR TITLE
Correctly replace free type variables in constructors

### DIFF
--- a/monticore-grammar/src/main/java/de/monticore/types3/util/OOWithinTypeBasicSymbolsResolver.java
+++ b/monticore-grammar/src/main/java/de/monticore/types3/util/OOWithinTypeBasicSymbolsResolver.java
@@ -5,16 +5,17 @@ import de.monticore.symbols.basicsymbols._symboltable.FunctionSymbol;
 import de.monticore.symbols.basicsymbols._symboltable.IBasicSymbolsScope;
 import de.monticore.symbols.oosymbols.OOSymbolsMill;
 import de.monticore.symbols.oosymbols._symboltable.MethodSymbol;
+import de.monticore.symbols.oosymbols.types3.OOSymbolsSymTypeRelations;
 import de.monticore.symboltable.modifiers.AccessModifier;
 import de.monticore.symboltable.modifiers.StaticAccessModifier;
 import de.monticore.types.check.SymTypeExpression;
+import de.monticore.types.check.SymTypeInferenceVariable;
 import de.monticore.types.check.SymTypeOfFunction;
+import de.monticore.types.check.SymTypeVariable;
+import de.monticore.types3.generics.TypeParameterRelations;
 import de.se_rwth.commons.logging.Log;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -84,7 +85,7 @@ public class OOWithinTypeBasicSymbolsResolver
     // do not search super types for constructors
     
     List<SymTypeOfFunction> symTypesFreeVarsReplaced = resolvedSymTypes.stream()
-        .map(t -> replaceFreeTypeVariables(thisType, t))
+        .map(this::replaceFreeConstructorTypeVariables)
         .map(SymTypeExpression::asFunctionType)
         .collect(Collectors.toList());
     
@@ -129,12 +130,20 @@ public class OOWithinTypeBasicSymbolsResolver
     );
   }
 
-  // Helper
+  protected SymTypeExpression replaceFreeConstructorTypeVariables(SymTypeExpression type) {
+    // 1. get unbound variable replacement map
+    Map<SymTypeVariable, SymTypeInferenceVariable> freeVarMap =
+        getUnboundVariableReplaceMap(Collections.emptyList(), type);
+    // 2. actually replace the free variables
+    SymTypeExpression typeVarsReplaced =
+        TypeParameterRelations.replaceTypeVariables(type, freeVarMap);
 
+    return typeVarsReplaced;
+  }
+  
   protected boolean isConstructor(FunctionSymbol func) {
     if (OOSymbolsMill.typeDispatcher().isOOSymbolsMethod(func)) {
-      MethodSymbol method =
-          OOSymbolsMill.typeDispatcher().asOOSymbolsMethod(func);
+      MethodSymbol method = OOSymbolsMill.typeDispatcher().asOOSymbolsMethod(func);
       return method.isIsConstructor();
     }
     return false;

--- a/monticore-grammar/src/main/java/de/monticore/types3/util/WithinTypeBasicSymbolsResolver.java
+++ b/monticore-grammar/src/main/java/de/monticore/types3/util/WithinTypeBasicSymbolsResolver.java
@@ -667,6 +667,21 @@ public class WithinTypeBasicSymbolsResolver {
     }
     return newModifier;
   }
+  
+  protected Map<SymTypeVariable, SymTypeInferenceVariable> getUnboundVariableReplaceMap(
+      List<SymTypeVariable> varsNotToReplace, SymTypeExpression type) {
+    // 1. find all variables
+    Map<SymTypeVariable, SymTypeInferenceVariable> allVarMap =
+        TypeParameterRelations.getFreeVariableReplaceMap(type, BasicSymbolsMill.scope());
+    // 2. get variables that actually need to be replaced (unbound)
+    Map<SymTypeVariable, SymTypeInferenceVariable> freeVarMap = new HashMap<>();
+    for (Map.Entry<SymTypeVariable, SymTypeInferenceVariable> e : allVarMap.entrySet()) {
+      if (varsNotToReplace.stream().noneMatch(e.getKey()::deepEquals)) {
+        freeVarMap.put(e.getKey(), e.getValue());
+      }
+    }
+    return freeVarMap;
+  }
 
   protected SymTypeExpression replaceFreeTypeVariables(
       SymTypeExpression thisType,
@@ -681,28 +696,20 @@ public class WithinTypeBasicSymbolsResolver {
     // }
     // In the example above, resolving f in B<T,R> will result in
     // () -> C<#FV,T,R> where #FV is a free type variable
-
-    // 1. find all variables
-    Map<SymTypeVariable, SymTypeInferenceVariable> allVarMap = TypeParameterRelations
-        .getFreeVariableReplaceMap(type, BasicSymbolsMill.scope());
-    // 2. find all type variables already bound by the type resolved in
-    List<SymTypeVariable> varsAlreadyBound = new SymTypeCollectionVisitor()
-        .calculate(thisType, SymTypeExpression::isTypeVariable).stream()
-        .map(SymTypeExpression::asTypeVariable)
-        .collect(Collectors.toList());
-    // 3. get variables that actually need to be replaced (unbound)
-    Map<SymTypeVariable, SymTypeInferenceVariable> freeVarMap = new HashMap<>();
-    for (Map.Entry<SymTypeVariable, SymTypeInferenceVariable> e : allVarMap.entrySet()) {
-      if (varsAlreadyBound.stream().noneMatch(e.getKey()::deepEquals)) {
-        freeVarMap.put(e.getKey(), e.getValue());
-      }
-    }
-    // 3.5 double check that the symTab does make any sense
+    
+    // 1. find all type variables already bound by the type resolved in
+    List<SymTypeVariable> varsAlreadyBound =
+        new SymTypeCollectionVisitor().calculate(thisType, SymTypeExpression::isTypeVariable)
+            .stream().map(SymTypeExpression::asTypeVariable).collect(Collectors.toList());
+    // 2. get unbound variable replacement map
+    Map<SymTypeVariable, SymTypeInferenceVariable> freeVarMap =
+        getUnboundVariableReplaceMap(varsAlreadyBound, type);
+    // 2.5 double check that the symTab does make any sense
     assertTypeVarsAreIncluded(type, freeVarMap.keySet());
-    // 4. actually replace the free variables
-    SymTypeExpression typeVarsReplaced = TypeParameterRelations
-        .replaceTypeVariables(type, freeVarMap);
-
+    // 3. actually replace the free variables
+    SymTypeExpression typeVarsReplaced =
+        TypeParameterRelations.replaceTypeVariables(type, freeVarMap);
+    
     return typeVarsReplaced;
   }
 

--- a/monticore-grammar/src/test/java/de/monticore/types3/UglyExpressionsTypeVisitorTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/types3/UglyExpressionsTypeVisitorTest.java
@@ -142,6 +142,14 @@ public class UglyExpressionsTypeVisitorTest extends AbstractTypeVisitorTest {
     checkExpr("new List()", "List<int>", "List<int>");
     checkExpr("new List(1)", "List<int>", "List<int>");
     checkExpr("new List(1)", "List<int>");
+    
+    checkExpr("new List<>()", "List<int>", "List<int>");
+    checkExpr("new List<>(1)", "List<int>", "List<int>");
+    checkExpr("new List<>(1)", "List<int>");
+    
+    checkExpr("new List<int>()", "List<int>", "List<int>");
+    checkExpr("new List<int>(1)", "List<int>", "List<int>");
+    checkExpr("new List<int>(1)", "List<int>");
   }
 
   @Test


### PR DESCRIPTION
The fix in #186 was insufficient and did not work in all cases.