### PR TITLE
Support DSTL patterns with the generated pretty printers

### DIFF
--- a/monticore-generator/src/main/java/de/monticore/codegen/prettyprint/MC2PPTranslation.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/prettyprint/MC2PPTranslation.java
@@ -78,16 +78,16 @@ public class MC2PPTranslation extends AbstractCreator<ASTMCGrammar, ASTCDCompila
     GrammarTraverser traverser = Grammar_WithConceptsMill.traverser();
 
     // Collect information about the NonTerminals first
-    NonTermAccessorVisitor nonTermAccessorVisitor = new NonTermAccessorVisitor();
-    traverser.add4Grammar(nonTermAccessorVisitor);
-    traverser.setGrammarHandler(new PrettyPrinterReducedTraverseHandler());
+    NonTermAccessorVisitorHandler nonTermAccessorCollector = new NonTermAccessorVisitorHandler();
+    traverser.add4Grammar(nonTermAccessorCollector);
+    traverser.setGrammarHandler(nonTermAccessorCollector);
     grammar.accept(traverser);
 
 
     // Traverse the Grammar ast and decorate the PP-handle methods
     PrettyPrinterGenerationVisitor transformer = new PrettyPrinterGenerationVisitor(glex,
             prettyPrinterCDClass,
-            nonTermAccessorVisitor.getClassProds());
+            nonTermAccessorCollector.getClassProds());
     traverser = Grammar_WithConceptsMill.traverser();
     traverser.setGrammarHandler(new PrettyPrinterReducedTraverseHandler());
     traverser.add4Grammar(transformer);

--- a/monticore-generator/src/main/java/de/monticore/codegen/prettyprint/NonTermAccessorVisitorHandler.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/prettyprint/NonTermAccessorVisitorHandler.java
@@ -14,7 +14,8 @@ import de.se_rwth.commons.StringTransformations;
 import java.util.*;
 
 
-public class NonTermAccessorVisitor implements GrammarVisitor2 {
+public class NonTermAccessorVisitorHandler extends PrettyPrinterReducedTraverseHandler
+        implements GrammarVisitor2 {
 
   protected final Map<String, ClassProdNonTermPrettyPrintData> classProds = new HashMap<>();
   protected ClassProdNonTermPrettyPrintData currentData;
@@ -23,6 +24,72 @@ public class NonTermAccessorVisitor implements GrammarVisitor2 {
 
   public Map<String, ClassProdNonTermPrettyPrintData> getClassProds() {
     return this.classProds;
+  }
+
+  @Override
+  public void traverse(ASTBlock node) {
+    int effIt = getEffectiveIteration(currentData.effectiveIterationStack.peek(), node.getIteration());
+    boolean doResetExhausted = effIt == ASTConstantsGrammar.DEFAULT || effIt == ASTConstantsGrammar.QUESTION;
+    traverseAltList(node.getAltList(), doResetExhausted);
+  }
+
+  @Override
+  public void traverse(ASTClassProd node) {
+    traverseAltList(node.getAltList(), true);
+  }
+
+  /**
+   * Support blocks which contain a NonTermRef once in each of its alts,
+   * such as  "P | P".
+   * This is only  supported in non-repeated ("trivial") blocks
+   * @param altList the list of alts of the block or class prod
+   * @param doResetExhausted whether the exhausted references should per-alt
+   */
+  protected void traverseAltList(List<ASTAlt> altList, boolean doResetExhausted) {
+    Set<String> exhaustedBefore = new HashSet<>(currentData.exhaustedNonTerminals);
+    Set<String> exhaustedAll = new HashSet<>();
+
+    Map<String, Integer> nonTerminalIterationBefore = new HashMap<>(currentData.nonTerminalIteration);
+    Map<String, Integer> nonTerminalIterationAll = new HashMap<>();
+
+    for (ASTAlt alt : altList) {
+      // Before each alt: reset the exhaustedNonTerminals and nonTerminalIterations to the before-state
+      if (doResetExhausted) {
+        currentData.exhaustedNonTerminals.clear();
+        currentData.exhaustedNonTerminals.addAll(exhaustedBefore);
+
+        currentData.nonTerminalIteration.clear();
+        currentData.nonTerminalIteration.putAll(nonTerminalIterationBefore);
+      }
+      // actually traverse
+      alt.accept(getTraverser());
+
+      if (doResetExhausted) {
+        // keep track of the alt's exhaustedNonTerminals
+        exhaustedAll.addAll(currentData.exhaustedNonTerminals);
+        // and their iteration
+        for (Map.Entry<String, Integer> e : currentData.nonTerminalIteration.entrySet()) {
+          nonTerminalIterationAll.compute(e.getKey(), (k, prevV) -> {
+            if (prevV == null || e.getValue().equals(prevV)) {
+              return e.getValue();
+            } else {
+              boolean isERepeated = e.getValue() == ASTConstantsGrammar.STAR || e.getValue() == ASTConstantsGrammar.PLUS;
+              boolean isOrigRepeated = prevV == ASTConstantsGrammar.STAR || prevV == ASTConstantsGrammar.PLUS;
+              // in case the iteration level changes between the alts -> non-trivial distinguishing
+              if (isERepeated != isOrigRepeated) {
+                currentData.erroringNonTerminals.add(e.getKey()); // indistinguishable alts (with our trivial approach)
+              }
+            }
+            return Math.max(prevV, e.getValue());
+          });
+        }
+      }
+    }
+
+    // After the block/prod: Add the exhausted non-terminals from all blocks
+    currentData.exhaustedNonTerminals.addAll(exhaustedAll);
+    for (var e : nonTerminalIterationAll.entrySet())
+      currentData.nonTerminalIteration.compute(e.getKey(), (k, v) -> Math.max(e.getValue(), v == null ? 0 : v));
   }
 
   @Override

--- a/monticore-generator/src/main/java/de/monticore/codegen/prettyprint/PrettyPrinterGenerationVisitor.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/prettyprint/PrettyPrinterGenerationVisitor.java
@@ -43,7 +43,7 @@ public class PrettyPrinterGenerationVisitor implements GrammarVisitor2 {
   protected static final String ITERATOR_PREFIX = "iter_";
 
   // data from the first phase
-  protected final Map<String, NonTermAccessorVisitor.ClassProdNonTermPrettyPrintData> classProds;
+  protected final Map<String, NonTermAccessorVisitorHandler.ClassProdNonTermPrettyPrintData> classProds;
 
   protected final ASTCDClass ppClass;
 
@@ -60,7 +60,7 @@ public class PrettyPrinterGenerationVisitor implements GrammarVisitor2 {
 
   // Changing attributes
   protected ASTClassProd currentClassProd;
-  protected NonTermAccessorVisitor.ClassProdNonTermPrettyPrintData currentClassProdData;
+  protected NonTermAccessorVisitorHandler.ClassProdNonTermPrettyPrintData currentClassProdData;
 
   protected String grammarName;
   protected Map<String, Collection<String>> replacedKeywords;
@@ -70,7 +70,7 @@ public class PrettyPrinterGenerationVisitor implements GrammarVisitor2 {
   protected NoSpacePredicateVisitor noSpacePredicateVisitor = new NoSpacePredicateVisitor();
   protected Grammar_WithConceptsTraverser noSpacePredicateTraverser;
 
-  public PrettyPrinterGenerationVisitor(GlobalExtensionManagement glex, ASTCDClass ppClass, Map<String, NonTermAccessorVisitor.ClassProdNonTermPrettyPrintData> classProds) {
+  public PrettyPrinterGenerationVisitor(GlobalExtensionManagement glex, ASTCDClass ppClass, Map<String, NonTermAccessorVisitorHandler.ClassProdNonTermPrettyPrintData> classProds) {
     this.glex = glex;
     this.ppClass = ppClass;
     this.classProds = classProds;

--- a/monticore-test/01.experiments/prettyPrinters/src/main/grammars/de/monticore/TestPrettyPrinters.mc4
+++ b/monticore-test/01.experiments/prettyPrinters/src/main/grammars/de/monticore/TestPrettyPrinters.mc4
@@ -330,4 +330,10 @@ grammar TestPrettyPrinters extends de.monticore.literals.MCCommonLiterals  {
       ("[[" (a:Name | b:TFSchema)? ":-" (newA:Name | newB:TFSchema)? "]]") |
       "Name" a:Name;
 
+		ExhaustedAlts1 = "a" A* | A*;
+		ExhaustedAlts2 = "a" A  | A*; // first or second alt -> non-trivial as long as no other guards exists
+		ExhaustedAlts3 = "a" A* | A ; // first or second alt -> non-trivial as long as no other guards exists
+		ExhaustedAlts4 = "a" A+ | ("hello" | A+) ;
+		ExhaustedAlts5 = "a" A+ | ("hello" | A ) ;  // first or second alt -> non-trivial as long as no other guards exists
+		ExhaustedAlts6 = ("a" A* | "b" A*)*; // indistinguishable alt (in repeated block)
 }

--- a/monticore-test/01.experiments/prettyPrinters/src/test/java/de/monticore/prettyprint/TestPrettyPrinterTest.java
+++ b/monticore-test/01.experiments/prettyPrinters/src/test/java/de/monticore/prettyprint/TestPrettyPrinterTest.java
@@ -840,4 +840,67 @@ public class TestPrettyPrinterTest extends PPTestClass {
     testPP("[[ $a :- $b ]]", KeywordAddingTestPrettyPrintersMill.parser()::parse_StringNestedFromTfIdentifier);
     testPP("[[ fooa :- foob]]", KeywordAddingTestPrettyPrintersMill.parser()::parse_StringNestedFromTfIdentifier);
   }
+
+  @Test
+  public void testExhaustedAlts1() throws IOException {
+    testPP("a A", TestPrettyPrintersMill.parser()::parse_StringExhaustedAlts1);
+    testPP("a A A", TestPrettyPrintersMill.parser()::parse_StringExhaustedAlts1);
+    testPP("A", TestPrettyPrintersMill.parser()::parse_StringExhaustedAlts1);
+    testPP("A A", TestPrettyPrintersMill.parser()::parse_StringExhaustedAlts1);
+  }
+
+  @Test
+  public void testExhaustedAlts2() throws IOException {
+    // Should the first or second alt be selected?
+    // The case-distinction is non-trivial => we abort
+    try {
+      testPP("a A", TestPrettyPrintersMill.parser()::parse_StringExhaustedAlts2);
+      Assertions.fail();
+    } catch (IllegalStateException expected) {
+      Assertions.assertEquals("The NonTerminal(s) [A] caused the automatic generation to fail", expected.getMessage());
+      MCAssertions.assertHasFinding(f -> f.getMsg().contains("The NonTerminal(s) [A] caused the automatic generation to fail"));
+    }
+  }
+
+  @Test
+  public void testExhaustedAlts3() throws IOException {
+    try {
+      testPP("a A", TestPrettyPrintersMill.parser()::parse_StringExhaustedAlts3);
+      Assertions.fail();
+    } catch (IllegalStateException expected) {
+      Assertions.assertEquals("The NonTerminal(s) [A] caused the automatic generation to fail", expected.getMessage());
+      MCAssertions.assertHasFinding(f -> f.getMsg().contains("The NonTerminal(s) [A] caused the automatic generation to fail"));
+    }
+  }
+
+
+  @Test
+  public void testExhaustedAlts4() throws IOException {
+    testPP("a A", TestPrettyPrintersMill.parser()::parse_StringExhaustedAlts4);
+    testPP("a A A", TestPrettyPrintersMill.parser()::parse_StringExhaustedAlts4);
+    testPP("hello", TestPrettyPrintersMill.parser()::parse_StringExhaustedAlts4);
+    testPP("A", TestPrettyPrintersMill.parser()::parse_StringExhaustedAlts4);
+    testPP("A A", TestPrettyPrintersMill.parser()::parse_StringExhaustedAlts4);
+  }
+
+  @Test
+  public void testExhaustedAlts5() throws IOException {
+    try {
+      testPP("hello", TestPrettyPrintersMill.parser()::parse_StringExhaustedAlts5);
+      Assertions.fail();
+    } catch (IllegalStateException expected) {
+      Assertions.assertEquals("The NonTerminal(s) [A] caused the automatic generation to fail", expected.getMessage());
+      MCAssertions.assertHasFinding(f -> f.getMsg().contains("The NonTerminal(s) [A] caused the automatic generation to fail"));
+    }  }
+
+  @Test
+  public void testExhaustedAlts6() throws IOException {
+    try {
+      testPP("a A", TestPrettyPrintersMill.parser()::parse_StringExhaustedAlts6);
+      Assertions.fail();
+    } catch (IllegalStateException expected) {
+      Assertions.assertEquals("The NonTerminal(s) [A] caused the automatic generation to fail", expected.getMessage());
+      MCAssertions.assertHasFinding(f -> f.getMsg().contains("The NonTerminal(s) [A] caused the automatic generation to fail"));
+    }
+  }
 }


### PR DESCRIPTION
* Productions of the kind `P = A*|A*` (as used by _Pat productions) are now automatically generated