### PR TITLE
Performance improvements (FreeMarker+Reporting)

### DIFF
--- a/monticore-runtime/src/main/java/de/monticore/generating/GeneratorSetup.java
+++ b/monticore-runtime/src/main/java/de/monticore/generating/GeneratorSetup.java
@@ -108,9 +108,9 @@ public class GeneratorSetup {
   public  Configuration getConfig() {
     Configuration config = new Configuration(FREEMARKER_VERSION);
 
-    DefaultObjectWrapper o = new DefaultObjectWrapperBuilder(GeneratorSetup.FREEMARKER_VERSION).build();
-    o.setTreatDefaultMethodsAsBeanMembers(true);
-    config.setObjectWrapper(o);
+    DefaultObjectWrapperBuilder oBuilder = new DefaultObjectWrapperBuilder(GeneratorSetup.FREEMARKER_VERSION);
+    oBuilder.setTreatDefaultMethodsAsBeanMembers(true);
+    config.setObjectWrapper(oBuilder.build());
     // don't look for templateName.de.ftl when templateName.ftl requested
     config.setLocalizedLookup(false);
     

--- a/monticore-runtime/src/main/java/de/monticore/generating/GeneratorSetup.java
+++ b/monticore-runtime/src/main/java/de/monticore/generating/GeneratorSetup.java
@@ -15,10 +15,9 @@ import de.monticore.io.paths.MCPath;
 import de.se_rwth.commons.logging.Log;
 import freemarker.cache.MultiTemplateLoader;
 import freemarker.cache.TemplateLoader;
-import freemarker.core.Macro;
 import freemarker.template.Configuration;
 import freemarker.template.DefaultObjectWrapper;
-import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.DefaultObjectWrapperBuilder;
 import freemarker.template.Version;
 
 import java.io.File;
@@ -109,7 +108,7 @@ public class GeneratorSetup {
   public  Configuration getConfig() {
     Configuration config = new Configuration(FREEMARKER_VERSION);
 
-    DefaultObjectWrapper o = new DefaultObjectWrapper(FREEMARKER_VERSION);
+    DefaultObjectWrapper o = new DefaultObjectWrapperBuilder(GeneratorSetup.FREEMARKER_VERSION).build();
     o.setTreatDefaultMethodsAsBeanMembers(true);
     config.setObjectWrapper(o);
     // don't look for templateName.de.ftl when templateName.ftl requested

--- a/monticore-runtime/src/main/java/de/monticore/generating/templateengine/freemarker/SimpleHashFactory.java
+++ b/monticore-runtime/src/main/java/de/monticore/generating/templateengine/freemarker/SimpleHashFactory.java
@@ -7,7 +7,7 @@ package de.monticore.generating.templateengine.freemarker;
 
 import de.monticore.generating.GeneratorSetup;
 import freemarker.log.Logger;
-import freemarker.template.DefaultObjectWrapper;
+import freemarker.template.DefaultObjectWrapperBuilder;
 import freemarker.template.ObjectWrapper;
 import freemarker.template.SimpleHash;
 
@@ -37,11 +37,11 @@ public class SimpleHashFactory {
   }
   
   public SimpleHash createSimpleHash() {
-    return new SimpleHash(new DefaultObjectWrapper(GeneratorSetup.FREEMARKER_VERSION));
+    return new SimpleHash(new DefaultObjectWrapperBuilder(GeneratorSetup.FREEMARKER_VERSION).build());
   }
   
   public SimpleHash createSimpleHash(Map<?, ?> map) {
-    return new SimpleHash(map, new DefaultObjectWrapper(GeneratorSetup.FREEMARKER_VERSION));
+    return new SimpleHash(map, new DefaultObjectWrapperBuilder(GeneratorSetup.FREEMARKER_VERSION).build());
   }
   
   public SimpleHash createSimpleHash(ObjectWrapper wrapper) {

--- a/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/commons/ReportCreator.java
+++ b/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/commons/ReportCreator.java
@@ -27,7 +27,7 @@ public class ReportCreator {
 	 */
 	public ReportCreator(String outputDir) {
 		this.outputDir = outputDir;
-		writers = new HashMap<File, BufferedWriter>();
+		writers = new HashMap<>();
 		File dir = new File(outputDir);
 		if (!dir.isDirectory()) {
 			dir.mkdirs();
@@ -76,7 +76,7 @@ public class ReportCreator {
 	 */
 	public void writeLineToFile(File file, String content) throws IOException {
 		BufferedWriter writer = writers.get(file);
-		writer.append(content + "\n");
+		writer.append(content).append("\n");
 	}
 
 	/**

--- a/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/HookPointReporter.java
+++ b/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/HookPointReporter.java
@@ -391,16 +391,16 @@ public class HookPointReporter extends AReporter {
   
   protected String getHookPointValue(HookPoint hp) {
     String value = null;
-    if (hp != null && hp instanceof TemplateHookPoint) {
+    if (hp instanceof TemplateHookPoint) {
       value = ((TemplateHookPoint) hp).getTemplateName();
       value = ReportingHelper.getTemplateName(value);
     }
-    else if (hp != null && hp instanceof StringHookPoint) {
+    else if (hp instanceof StringHookPoint) {
       value = ((StringHookPoint) hp).getValue();
       value = ReportingHelper.formatStringToReportingString(value,
           ReportingConstants.REPORTING_ROW_LENGTH - ReportingConstants.FORMAT_LENGTH_2);
     }
-    else if (hp != null && hp instanceof CodeHookPoint) {
+    else if (hp instanceof CodeHookPoint) {
       value = ((CodeHookPoint) hp).getClass().getName();
       value = Names.getSimpleName(value);
     }

--- a/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/InstantiationsReporter.java
+++ b/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/InstantiationsReporter.java
@@ -56,13 +56,7 @@ public class InstantiationsReporter extends AReporter {
   @Override
   public void reportInstantiate(String className, List<Object> params) {
     className = Names.getSimpleName(className);
-    if (instantiateCount.containsKey(className)) {
-      Integer actualCount = instantiateCount.get(className);
-      instantiateCount.put(className, actualCount + 1);
-    }
-    else {
-      instantiateCount.put(className, 1);
-    }
+    instantiateCount.merge(className, 1, Integer::sum);
   }
   
   @Override

--- a/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/NodeTreeDecoratedReporter.java
+++ b/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/NodeTreeDecoratedReporter.java
@@ -249,15 +249,15 @@ public class NodeTreeDecoratedReporter extends AReporter {
   
   protected String getHookPointValue(HookPoint hp) {
     String value = null;
-    if (hp != null && hp instanceof TemplateHookPoint) {
+    if (hp instanceof TemplateHookPoint) {
       value = ((TemplateHookPoint) hp).getTemplateName();
       value = ReportingHelper.getTemplateName(value);
     }
-    else if (hp != null && hp instanceof StringHookPoint) {
+    else if (hp instanceof StringHookPoint) {
       value = ((StringHookPoint) hp).getValue();
       value = ReportingHelper.formatStringToReportingString(value, 50);
     }
-    else if (hp != null && hp instanceof CodeHookPoint) {
+    else if (hp instanceof CodeHookPoint) {
       value = ((CodeHookPoint) hp).getClass().getName();
       value = Names.getSimpleName(value);
     }

--- a/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/NodeTreeReporter.java
+++ b/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/NodeTreeReporter.java
@@ -93,7 +93,7 @@ public class NodeTreeReporter extends AReporter {
   public void reportCallAfterHookPoint(String oldTemplate, Collection<HookPoint> afterHPs,
       ASTNode ast) {
     for (HookPoint hp : afterHPs) {
-      if (hp != null && hp instanceof TemplateHookPoint) {
+      if (hp instanceof TemplateHookPoint) {
         String aident = compactStr(ast);
         nodeVisits.merge(aident, 1, Integer::sum);
       }
@@ -108,7 +108,7 @@ public class NodeTreeReporter extends AReporter {
   public void reportCallBeforeHookPoint(String oldTemplate, Collection<HookPoint> beforeHPs,
       ASTNode ast) {
     for (HookPoint hp : beforeHPs) {
-      if (hp != null && hp instanceof TemplateHookPoint) {
+      if (hp instanceof TemplateHookPoint) {
         String aident = compactStr(ast);
         nodeVisits.merge(aident, 1, Integer::sum);
       }
@@ -122,7 +122,7 @@ public class NodeTreeReporter extends AReporter {
   @Override
   public void reportCallReplacementHookPoint(String oldTemplate, List<HookPoint> hps, ASTNode ast) {
     for (HookPoint hp : hps) {
-      if (hp != null && hp instanceof TemplateHookPoint) {
+      if (hp instanceof TemplateHookPoint) {
         String aident = compactStr(ast);
         nodeVisits.merge(aident, 1, Integer::sum);
       }
@@ -137,7 +137,7 @@ public class NodeTreeReporter extends AReporter {
   public void reportCallSpecificReplacementHookPoint(String oldTemplate, List<HookPoint> hps,
       ASTNode ast) {
     for (HookPoint hp : hps) {
-      if (hp != null && hp instanceof TemplateHookPoint) {
+      if (hp instanceof TemplateHookPoint) {
         String aident = compactStr(ast);
         nodeVisits.merge(aident, 1, Integer::sum);
       }
@@ -150,7 +150,7 @@ public class NodeTreeReporter extends AReporter {
    */
   @Override
   public void reportCallHookPointStart(String hookName, HookPoint hp, ASTNode ast) {
-    if (hp != null && hp instanceof TemplateHookPoint) {
+    if (hp instanceof TemplateHookPoint) {
       String aident = compactStr(ast);
       nodeVisits.merge(aident, 1, Integer::sum);
     }

--- a/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/NodeTypesReporter.java
+++ b/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/NodeTypesReporter.java
@@ -84,19 +84,8 @@ public class NodeTypesReporter extends AReporter {
     allKeys.addAll(nodetypeCountPos2.keySet());
     allKeys.addAll(nodeTypeCount2.keySet());
     for (String key : allKeys) {
-      int val1, val2;
-      if (nodeTypeCount2.containsKey(key)) {
-        val1 = nodeTypeCount2.get(key);
-      }
-      else {
-        val1 = 0;
-      }
-      if (nodetypeCountPos2.containsKey(key)) {
-        val2 = nodetypeCountPos2.get(key);
-      }
-      else {
-        val2 = 0;
-      }
+      int val1 = nodeTypeCount2.getOrDefault(key, 0);
+      int val2 = nodetypeCountPos2.getOrDefault(key, 0);
       dif.put(key, val1 - val2);
     }
     return dif;

--- a/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/SummaryReporter.java
+++ b/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/SummaryReporter.java
@@ -275,13 +275,13 @@ public class SummaryReporter extends AReporter {
   public void reportCallAfterHookPoint(String oldTemplate, Collection<HookPoint> afterHPs,
       ASTNode ast) {
     for (HookPoint hp : afterHPs) {
-      if (hp != null && hp instanceof CodeHookPoint) {
+      if (hp instanceof CodeHookPoint) {
         numCallCodeHookpoints++;
       }
-      else if (hp != null && hp instanceof TemplateHookPoint) {
+      else if (hp instanceof TemplateHookPoint) {
         numCallTemplateHookpoints++;
       }
-      else if (hp != null && hp instanceof StringHookPoint) {
+      else if (hp instanceof StringHookPoint) {
         numCallStringHookpoints++;
       }
     }
@@ -295,13 +295,13 @@ public class SummaryReporter extends AReporter {
   public void reportCallBeforeHookPoint(String oldTemplate, Collection<HookPoint> beforeHPs,
       ASTNode ast) {
     for (HookPoint hp : beforeHPs) {
-      if (hp != null && hp instanceof CodeHookPoint) {
+      if (hp instanceof CodeHookPoint) {
         numCallCodeHookpoints++;
       }
-      else if (hp != null && hp instanceof TemplateHookPoint) {
+      else if (hp instanceof TemplateHookPoint) {
         numCallTemplateHookpoints++;
       }
-      else if (hp != null && hp instanceof StringHookPoint) {
+      else if (hp instanceof StringHookPoint) {
         numCallStringHookpoints++;
       }
     }
@@ -314,13 +314,13 @@ public class SummaryReporter extends AReporter {
   @Override
   public void reportCallReplacementHookPoint(String oldTemplate, List<HookPoint> hps, ASTNode ast) {
     for (HookPoint hp : hps) {
-      if (hp != null && hp instanceof CodeHookPoint) {
+      if (hp instanceof CodeHookPoint) {
         numCallCodeHookpoints++;
       }
-      else if (hp != null && hp instanceof TemplateHookPoint) {
+      else if (hp instanceof TemplateHookPoint) {
         numCallTemplateHookpoints++;
       }
-      else if (hp != null && hp instanceof StringHookPoint) {
+      else if (hp instanceof StringHookPoint) {
         numCallStringHookpoints++;
       }
     }
@@ -475,13 +475,13 @@ public class SummaryReporter extends AReporter {
    */
   @Override
   public void reportSetHookPoint(String hookName, HookPoint hp) {
-    if (hp != null && hp instanceof CodeHookPoint) {
+    if (hp instanceof CodeHookPoint) {
       numSetCodeHookpoints++;
     }
-    else if (hp != null && hp instanceof TemplateHookPoint) {
+    else if (hp instanceof TemplateHookPoint) {
       numSetTemplateHookpoints++;
     }
-    else if (hp != null && hp instanceof StringHookPoint) {
+    else if (hp instanceof StringHookPoint) {
       numSetStringHookpoints++;
     }
   }
@@ -492,13 +492,13 @@ public class SummaryReporter extends AReporter {
    */
   @Override
   public void reportCallHookPointStart(String hookName, HookPoint hp, ASTNode ast) {
-    if (hp != null && hp instanceof CodeHookPoint) {
+    if (hp instanceof CodeHookPoint) {
       numCallCodeHookpoints++;
     }
-    else if (hp != null && hp instanceof TemplateHookPoint) {
+    else if (hp instanceof TemplateHookPoint) {
       numCallTemplateHookpoints++;
     }
-    else if (hp != null && hp instanceof StringHookPoint) {
+    else if (hp instanceof StringHookPoint) {
       numCallStringHookpoints++;
     }
     calledUnsetHookpoints.add(ReportingHelper.getHookPointName(hookName));
@@ -521,13 +521,13 @@ public class SummaryReporter extends AReporter {
   @Override
   public void reportSetBeforeTemplate(String template, Optional<ASTNode> ast, List<? extends HookPoint> beforeHps) {
     for (HookPoint hp : beforeHps) {
-      if (hp != null && hp instanceof CodeHookPoint) {
+      if (hp instanceof CodeHookPoint) {
         numSetCodeHookpoints++;
       }
-      else if (hp != null && hp instanceof TemplateHookPoint) {
+      else if (hp instanceof TemplateHookPoint) {
         numSetTemplateHookpoints++;
       }
-      else if (hp != null && hp instanceof StringHookPoint) {
+      else if (hp instanceof StringHookPoint) {
         numSetStringHookpoints++;
       }
     }
@@ -540,13 +540,13 @@ public class SummaryReporter extends AReporter {
   @Override
   public void reportSetAfterTemplate(String template, Optional<ASTNode> ast, List<? extends HookPoint> afterHps) {
     for (HookPoint hp : afterHps) {
-      if (hp != null && hp instanceof CodeHookPoint) {
+      if (hp instanceof CodeHookPoint) {
         numSetCodeHookpoints++;
       }
-      else if (hp != null && hp instanceof TemplateHookPoint) {
+      else if (hp instanceof TemplateHookPoint) {
         numSetTemplateHookpoints++;
       }
-      else if (hp != null && hp instanceof StringHookPoint) {
+      else if (hp instanceof StringHookPoint) {
         numSetStringHookpoints++;
       }
     }
@@ -559,13 +559,13 @@ public class SummaryReporter extends AReporter {
   @Override
   public void reportTemplateReplacement(String oldTemplate, List<? extends HookPoint> newHps) {
     for (HookPoint hp : newHps) {
-      if (hp != null && hp instanceof CodeHookPoint) {
+      if (hp instanceof CodeHookPoint) {
         numSetCodeHookpoints++;
       }
-      else if (hp != null && hp instanceof TemplateHookPoint) {
+      else if (hp instanceof TemplateHookPoint) {
         numSetTemplateHookpoints++;
       }
-      else if (hp != null && hp instanceof StringHookPoint) {
+      else if (hp instanceof StringHookPoint) {
         numSetStringHookpoints++;
       }
     }

--- a/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/TemplateTreeReporter.java
+++ b/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/TemplateTreeReporter.java
@@ -223,16 +223,16 @@ public class TemplateTreeReporter extends AReporter {
   
   protected String getHookPointValue(HookPoint hp) {
     String value = null;
-    if (hp != null && hp instanceof TemplateHookPoint) {
+    if (hp instanceof TemplateHookPoint) {
       value = ((TemplateHookPoint) hp).getTemplateName();
       value = ReportingHelper.getTemplateName(value);
     }
-    else if (hp != null && hp instanceof StringHookPoint) {
+    else if (hp instanceof StringHookPoint) {
       value = ((StringHookPoint) hp).getValue();
       value = ReportingHelper.formatStringToReportingString(value,
           ReportingConstants.REPORTING_ROW_LENGTH - ReportingConstants.FORMAT_LENGTH_2);
     }
-    else if (hp != null && hp instanceof CodeHookPoint) {
+    else if (hp instanceof CodeHookPoint) {
       value = ((CodeHookPoint) hp).getClass().getName();
       value = Names.getSimpleName(value);
     }

--- a/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/TemplatesReporter.java
+++ b/monticore-runtime/src/main/java/de/monticore/generating/templateengine/reporting/reporter/TemplatesReporter.java
@@ -98,32 +98,17 @@ public class TemplatesReporter extends AReporter {
   public void reportTemplateStart(String templatename, ASTNode ast) {
     Set<String> hwTemplates = repository.getAllHWTemplateNames();
     // if template is handwritten
-    if (hwTemplates.contains(templatename.replaceAll("\\.", "/").concat(".")
-        .concat(ReportingConstants.TEMPLATE_FILE_EXTENSION))) {
-      realHWTemplateNames.add(templatename.replaceAll("\\.", "/").concat(".")
-          .concat(ReportingConstants.TEMPLATE_FILE_EXTENSION));
+    String templateNameSanitized = templatename.replaceAll("\\.", "/").concat(".")
+            .concat(ReportingConstants.TEMPLATE_FILE_EXTENSION);
+    if (hwTemplates.contains(templateNameSanitized)) {
+      realHWTemplateNames.add(templateNameSanitized);
       templatename = ReportingHelper.getTemplateName(templatename);
-      
-      if (hwTemplateCount.containsKey(templatename)) {
-        Integer actualCount = hwTemplateCount.get(templatename);
-        hwTemplateCount.put(templatename, actualCount + 1);
-      }
-      else {
-        hwTemplateCount.put(templatename, 1);
-      }
+      hwTemplateCount.merge(templatename, 1, Integer::sum);
     }
     else {
-      realTemplateNames.add(templatename.replaceAll("\\.", "/").concat(".")
-          .concat(ReportingConstants.TEMPLATE_FILE_EXTENSION));
+      realTemplateNames.add(templateNameSanitized);
       templatename = ReportingHelper.getTemplateName(templatename);
-      
-      if (templateCount.containsKey(templatename)) {
-        Integer actualCount = templateCount.get(templatename);
-        templateCount.put(templatename, actualCount + 1);
-      }
-      else {
-        templateCount.put(templatename, 1);
-      }
+      templateCount.merge(templatename, 1, Integer::sum);
     }
   }
   


### PR DESCRIPTION
* Use the [FreeMarker class introspection cache](https://freemarker.apache.org/docs/api/freemarker/template/DefaultObjectWrapper.html#:~:text=Instances%20created%20with%20this%20constructor%20won%27t%20share%20the%20class%20introspection%20caches%20with%20other%20instances)
* Various reporting cleanups 