### PR TITLE
Fix symbol surrogate equals

### DIFF
--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolDecorator.java
@@ -124,7 +124,8 @@ public class SymbolDecorator extends AbstractCreator<ASTCDClass, ASTCDClass> {
               .flatMap(List::stream)
               .collect(Collectors.toList());
     }
-    symbolMethods.add(createEqualsMethod());
+    symbolMethods.add(createEqualsMethod(symbolName));
+    symbolMethods.add(createGetThis(symbolName));
 
     ASTCDParameter constructorParam = getCDParameterFacade().createParameter(getMCTypeFacade().createStringType(), NAME_VAR);
     ASTCDConstructor constructor = getCDConstructorFacade().createConstructor(PUBLIC.build(), symbolName, constructorParam);
@@ -183,11 +184,17 @@ public class SymbolDecorator extends AbstractCreator<ASTCDClass, ASTCDClass> {
     return symbolClass;
   }
 
-  protected ASTCDMethod createEqualsMethod() {
+  protected ASTCDMethod createEqualsMethod(String symbolClass) {
     ASTCDParameter parameter = getCDParameterFacade().createParameter(getMCTypeFacade().createQualifiedType("Object"), "obj");
     ASTCDMethod method = getCDMethodFacade().createMethod(PUBLIC.build(), getMCTypeFacade().createBooleanType(), "equals", parameter);
-    this.replaceTemplate(EMPTY_BODY, method, new TemplateHookPoint(TEMPLATE_PATH + "Equals"));
+    this.replaceTemplate(EMPTY_BODY, method, new TemplateHookPoint(TEMPLATE_PATH + "Equals", symbolClass));
     this.replaceTemplate(ANNOTATIONS, method, new StringHookPoint("@Override"));
+    return method;
+  }
+
+  protected ASTCDMethod createGetThis(String symbolClass) {
+    ASTCDMethod method = getCDMethodFacade().createMethod(PROTECTED.build(), symbolClass, "getThis");
+    this.replaceTemplate(EMPTY_BODY, method, new StringHookPoint("return (" + symbolClass + ") this;"));
     return method;
   }
 

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolDecorator.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 
 import static de.monticore.cd.codegen.CD2JavaTemplates.EMPTY_BODY;
 import static de.monticore.cd.codegen.CD2JavaTemplates.VALUE;
+import static de.monticore.cd.codegen.CD2JavaTemplates.ANNOTATIONS;
 import static de.monticore.cd.facade.CDModifier.PROTECTED;
 import static de.monticore.cd.facade.CDModifier.PUBLIC;
 import static de.monticore.codegen.cd2java._ast.ast_class.ASTConstants.ACCEPT_METHOD;
@@ -123,6 +124,7 @@ public class SymbolDecorator extends AbstractCreator<ASTCDClass, ASTCDClass> {
               .flatMap(List::stream)
               .collect(Collectors.toList());
     }
+    symbolMethods.add(createEqualsMethod());
 
     ASTCDParameter constructorParam = getCDParameterFacade().createParameter(getMCTypeFacade().createStringType(), NAME_VAR);
     ASTCDConstructor constructor = getCDConstructorFacade().createConstructor(PUBLIC.build(), symbolName, constructorParam);
@@ -179,6 +181,14 @@ public class SymbolDecorator extends AbstractCreator<ASTCDClass, ASTCDClass> {
       symbolClass.setCDExtendUsage(symbolInput.getCDExtendUsage());
     }
     return symbolClass;
+  }
+
+  protected ASTCDMethod createEqualsMethod() {
+    ASTCDParameter parameter = getCDParameterFacade().createParameter(getMCTypeFacade().createQualifiedType("Object"), "obj");
+    ASTCDMethod method = getCDMethodFacade().createMethod(PUBLIC.build(), getMCTypeFacade().createBooleanType(), "equals", parameter);
+    this.replaceTemplate(EMPTY_BODY, method, new TemplateHookPoint(TEMPLATE_PATH + "Equals"));
+    this.replaceTemplate(ANNOTATIONS, method, new StringHookPoint("@Override"));
+    return method;
   }
 
   protected List<ASTCDMethod> createOverridingSymbolMethods(String astClassName, String scopeInterface) {

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolSurrogateDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolSurrogateDecorator.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static de.monticore.cd.codegen.CD2JavaTemplates.ANNOTATIONS;
 import static de.monticore.cd.codegen.CD2JavaTemplates.EMPTY_BODY;
 import static de.monticore.cd.facade.CDModifier.PROTECTED;
 import static de.monticore.cd.facade.CDModifier.PUBLIC;
@@ -125,6 +126,7 @@ public class SymbolSurrogateDecorator extends AbstractCreator<ASTCDClass, ASTCDC
       .addAllCDMembers(nameMethods)
       .addAllCDMembers(delegateSymbolRuleAttributeMethods)
       .addAllCDMembers(delegateAccecptMethods)
+      .addCDMember(createGetThis(this.symbolTableService.getSymbolSimpleName(symbolInput)))
       .addCDMember(createGetFullNameMethod())
       .addCDMember(createOverridenDeterminePackageName())
       .addCDMember(createOverridenDetermineFullName())
@@ -145,6 +147,13 @@ public class SymbolSurrogateDecorator extends AbstractCreator<ASTCDClass, ASTCDC
     this.replaceTemplate(EMPTY_BODY, method, new TemplateHookPoint(TEMPLATE_PATH + "SetEnclosingScope4SymbolSurrogate", enclosingScopeAttribute, scopeName));
     return method;
   }
+
+  protected ASTCDMethod createGetThis(String symbolClass) {
+    ASTCDMethod method = getCDMethodFacade().createMethod(PUBLIC.build(), symbolClass, "getThis");
+    this.replaceTemplate(EMPTY_BODY, method, new TemplateHookPoint(TEMPLATE_PATH + "GetThis"));
+    this.replaceTemplate(ANNOTATIONS, method, new StringHookPoint("@Override"));
+    return method;
+  }
   
   protected ASTCDConstructor createConstructor(String symbolSurrogateClass) {
     ASTCDParameter nameParameter = getCDParameterFacade().createParameter(String.class, NAME_VAR);
@@ -152,6 +161,7 @@ public class SymbolSurrogateDecorator extends AbstractCreator<ASTCDClass, ASTCDC
     this.replaceTemplate(EMPTY_BODY, constructor, new TemplateHookPoint(TEMPLATE_PATH + "ConstructorSymbolSurrogate"));
     return constructor;
   }
+
   
   protected ASTCDAttribute createNameAttribute() {
     return getCDAttributeFacade().createAttribute(PROTECTED.build(), "String", "name");

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolSurrogateDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolSurrogateDecorator.java
@@ -162,7 +162,6 @@ public class SymbolSurrogateDecorator extends AbstractCreator<ASTCDClass, ASTCDC
     return constructor;
   }
 
-  
   protected ASTCDAttribute createNameAttribute() {
     return getCDAttributeFacade().createAttribute(PROTECTED.build(), "String", "name");
   }

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolSurrogateDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolSurrogateDecorator.java
@@ -149,8 +149,8 @@ public class SymbolSurrogateDecorator extends AbstractCreator<ASTCDClass, ASTCDC
   }
 
   protected ASTCDMethod createGetThis(String symbolClass) {
-    ASTCDMethod method = getCDMethodFacade().createMethod(PUBLIC.build(), symbolClass, "getThis");
-    this.replaceTemplate(EMPTY_BODY, method, new TemplateHookPoint(TEMPLATE_PATH + "GetThis"));
+    ASTCDMethod method = getCDMethodFacade().createMethod(PROTECTED.build(), symbolClass, "getThis");
+    this.replaceTemplate(EMPTY_BODY, method, new TemplateHookPoint(TEMPLATE_PATH + "GetThis", symbolClass));
     this.replaceTemplate(ANNOTATIONS, method, new StringHookPoint("@Override"));
     return method;
   }
@@ -209,7 +209,7 @@ public class SymbolSurrogateDecorator extends AbstractCreator<ASTCDClass, ASTCDC
       symbolName, simpleName, scopeName, generatedError));
     return method;
   }
-  
+
   protected ASTCDMethod createGetFullNameMethod() {
     ASTCDMethod method = getCDMethodFacade().createMethod(PUBLIC.build(), getMCTypeFacade().createStringType(), "getFullName");
     this.replaceTemplate(EMPTY_BODY, method, new TemplateHookPoint(TEMPLATE_PATH + "GetFullName"));

--- a/monticore-generator/src/main/resources/_symboltable/symbol/Equals.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/symbol/Equals.ftl
@@ -1,0 +1,7 @@
+  if(!(obj instanceof de.monticore.symboltable.ISymbol)) {
+    return false;
+  }
+  de.monticore.symboltable.ISymbol s1 = getThis();
+  de.monticore.symboltable.ISymbol s2 = ((de.monticore.symboltable.ISymbol) obj).getThis();
+
+  return s1 == s2;

--- a/monticore-generator/src/main/resources/_symboltable/symbol/Equals.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/symbol/Equals.ftl
@@ -1,7 +1,10 @@
-  if(!(obj instanceof de.monticore.symboltable.ISymbol)) {
+<#-- (c) https://github.com/MontiCore/monticore -->
+${tc.signature("symbolName")}
+
+  if(!(obj instanceof ${symbolName})) {
     return false;
   }
-  de.monticore.symboltable.ISymbol s1 = getThis();
-  de.monticore.symboltable.ISymbol s2 = ((de.monticore.symboltable.ISymbol) obj).getThis();
+  ${symbolName} s1 = getThis();
+  ${symbolName} s2 = ((${symbolName}) obj).getThis();
 
   return s1 == s2;

--- a/monticore-generator/src/main/resources/_symboltable/symbolsurrogate/GetThis.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/symbolsurrogate/GetThis.ftl
@@ -1,0 +1,4 @@
+  if(checkLazyLoadDelegate()) {
+    return lazyLoadDelegate();
+  }
+  return this;

--- a/monticore-generator/src/main/resources/_symboltable/symbolsurrogate/GetThis.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/symbolsurrogate/GetThis.ftl
@@ -1,4 +1,7 @@
+<#-- (c) https://github.com/MontiCore/monticore -->
+${tc.signature("symbolName")}
+
   if(checkLazyLoadDelegate()) {
     return lazyLoadDelegate();
   }
-  return this;
+  return (${symbolName}) this;

--- a/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolDecoratorTest.java
+++ b/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolDecoratorTest.java
@@ -263,7 +263,7 @@ public class SymbolDecoratorTest extends DecoratorTestCase {
 
   @Test
   public void testMethods() {
-    assertEquals(24, symbolClassAutomaton.getCDMethodList().size());
+    assertEquals(25, symbolClassAutomaton.getCDMethodList().size());
   }
 
   @Test
@@ -617,7 +617,7 @@ public class SymbolDecoratorTest extends DecoratorTestCase {
 
   @Test
   public void testMethodsStateSymbol() {
-    assertEquals(22, symbolClassState.getCDMethodList().size());
+    assertEquals(23, symbolClassState.getCDMethodList().size());
   
     assertTrue(Log.getFindings().isEmpty());
   }

--- a/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolDecoratorTest.java
+++ b/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolDecoratorTest.java
@@ -263,7 +263,7 @@ public class SymbolDecoratorTest extends DecoratorTestCase {
 
   @Test
   public void testMethods() {
-    assertEquals(23, symbolClassAutomaton.getCDMethodList().size());
+    assertEquals(24, symbolClassAutomaton.getCDMethodList().size());
   }
 
   @Test
@@ -617,7 +617,7 @@ public class SymbolDecoratorTest extends DecoratorTestCase {
 
   @Test
   public void testMethodsStateSymbol() {
-    assertEquals(21, symbolClassState.getCDMethodList().size());
+    assertEquals(22, symbolClassState.getCDMethodList().size());
   
     assertTrue(Log.getFindings().isEmpty());
   }

--- a/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolSurrogateDecoratorTest.java
+++ b/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolSurrogateDecoratorTest.java
@@ -141,7 +141,8 @@ public class SymbolSurrogateDecoratorTest extends DecoratorTestCase {
 
   @Test
   public void testMethods() {
-    assertEquals(15, symbolClassAutomaton.getCDMethodList().size());
+
+    assertEquals(16, symbolClassAutomaton.getCDMethodList().size());
   
     assertTrue(Log.getFindings().isEmpty());
   }

--- a/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolSurrogateDecoratorTest.java
+++ b/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolSurrogateDecoratorTest.java
@@ -302,7 +302,6 @@ public class SymbolSurrogateDecoratorTest extends DecoratorTestCase {
     assertTrue(Log.getFindings().isEmpty());
   }
 
-
   @Test
   public void testGeneratedCodeFoo() {
     GeneratorSetup generatorSetup = new GeneratorSetup();

--- a/monticore-grammar/src/test/java/de/monticore/symbols/basicsymbols/_symboltable/TypeSymbolSurrogateTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/symbols/basicsymbols/_symboltable/TypeSymbolSurrogateTest.java
@@ -5,8 +5,10 @@ import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
 import de.monticore.symboltable.modifiers.BasicAccessModifier;
 import de.monticore.types.check.SymTypeExpression;
 import de.monticore.types.check.SymTypeExpressionFactory;
+import de.se_rwth.commons.logging.LogStub;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -15,6 +17,12 @@ import java.util.Map;
 
 /** Tests {@link TypeSymbolSurrogate} */
 public class TypeSymbolSurrogateTest {
+
+  @BeforeEach
+  void setUp() {
+    LogStub.init();
+    BasicSymbolsMill.init();
+  }
 
   @Test
   public void setSpannedScopeShouldSkipSurrogate() {

--- a/monticore-grammar/src/test/java/de/monticore/symbols/basicsymbols/_symboltable/TypeSymbolSurrogateTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/symbols/basicsymbols/_symboltable/TypeSymbolSurrogateTest.java
@@ -106,6 +106,125 @@ public class TypeSymbolSurrogateTest {
     Assertions.assertArrayEquals(new TypeVarSymbol[]{typeParam}, typeParams.toArray());
   }
 
+  @Test @SuppressWarnings({"EqualsWithItself", "ConstantConditions"})
+  void equalsShouldEqualSame() {
+    // Given
+    TypeSymbolSurrogate surrogate = BasicSymbolsMill.typeSymbolSurrogateBuilder()
+            .setName("Type")
+            .setEnclosingScope(BasicSymbolsMill.scope())
+            .build();
+
+    // When
+    boolean result = surrogate.equals(surrogate);
+
+    // Then
+    Assertions.assertTrue(result);
+  }
+
+  @Test
+  void equalsShouldNotEqualDifferent1() {
+    // Given
+    TypeSymbolSurrogate surrogate1 = BasicSymbolsMill.typeSymbolSurrogateBuilder()
+            .setName("Type1")
+            .setEnclosingScope(BasicSymbolsMill.scope())
+            .build();
+
+    TypeSymbolSurrogate surrogate2 = BasicSymbolsMill.typeSymbolSurrogateBuilder()
+            .setName("Type2")
+            .setEnclosingScope(BasicSymbolsMill.scope())
+            .build();
+
+    // When
+    boolean result = surrogate1.equals(surrogate2);
+
+    // Then
+    Assertions.assertFalse(result);
+  }
+
+  @Test
+  void equalsShouldNotEqualDifferent2() {
+    // Given
+    IBasicSymbolsScope scope = BasicSymbolsMill.scope();
+
+    TypeSymbol symbol1 = BasicSymbolsMill.typeSymbolBuilder()
+            .setName("Type1")
+            .setSpannedScope(BasicSymbolsMill.scope())
+            .build();
+
+    scope.add(symbol1);
+
+    TypeSymbolSurrogate surrogate1 = BasicSymbolsMill.typeSymbolSurrogateBuilder()
+            .setName("Type1")
+            .setEnclosingScope(BasicSymbolsMill.scope())
+            .build();
+
+    TypeSymbol symbol2 = BasicSymbolsMill.typeSymbolBuilder()
+            .setName("Type2")
+            .setSpannedScope(BasicSymbolsMill.scope())
+            .build();
+
+    scope.add(symbol2);
+
+    TypeSymbolSurrogate surrogate2 = BasicSymbolsMill.typeSymbolSurrogateBuilder()
+            .setName("Type2")
+            .setEnclosingScope(BasicSymbolsMill.scope())
+            .build();
+
+    // When
+    boolean result = surrogate1.equals(surrogate2);
+
+    // Then
+    Assertions.assertFalse(result);
+  }
+
+  @Test
+  void equalsShouldEqualSymbol() {
+    // Given
+    IBasicSymbolsScope scope = BasicSymbolsMill.scope();
+
+    TypeSymbol symbol = BasicSymbolsMill.typeSymbolBuilder()
+            .setName("Type")
+            .setSpannedScope(BasicSymbolsMill.scope())
+            .build();
+
+    scope.add(symbol);
+
+    TypeSymbolSurrogate surrogate = BasicSymbolsMill.typeSymbolSurrogateBuilder()
+            .setName("Type")
+            .setEnclosingScope(scope)
+            .build();
+
+    // When
+    boolean result = surrogate.equals(symbol);
+
+    // Then
+    Assertions.assertTrue(result);
+  }
+
+  @Test
+  void equalsShouldNotEqualSymbol() {
+    // Given
+    IBasicSymbolsScope scope = BasicSymbolsMill.scope();
+
+    TypeSymbol symbol = BasicSymbolsMill.typeSymbolBuilder()
+            .setName("Type1")
+            .setSpannedScope(BasicSymbolsMill.scope())
+            .build();
+
+    scope.add(symbol);
+
+    TypeSymbolSurrogate surrogate = BasicSymbolsMill.typeSymbolSurrogateBuilder()
+            .setName("Type2")
+            .setEnclosingScope(scope)
+            .build();
+
+    // When
+    boolean result = surrogate.equals(symbol);
+
+    // Then
+    Assertions.assertFalse(result);
+  }
+
   /**
    * Adds a type parameter to the type.
    *

--- a/monticore-grammar/src/test/java/de/monticore/symbols/basicsymbols/_symboltable/TypeSymbolTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/symbols/basicsymbols/_symboltable/TypeSymbolTest.java
@@ -1,0 +1,99 @@
+package de.monticore.symbols.basicsymbols._symboltable;
+
+import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
+import de.se_rwth.commons.logging.LogStub;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TypeSymbolTest {
+
+  @BeforeEach
+  void setUp() {
+    LogStub.init();
+    BasicSymbolsMill.init();
+  }
+
+  @Test @SuppressWarnings({"EqualsWithItself", "ConstantConditions"})
+  void equalsShouldEqualSame() {
+    // Given
+    TypeSymbol symbol = BasicSymbolsMill.typeSymbolBuilder()
+            .setName("Type")
+            .setEnclosingScope(BasicSymbolsMill.scope())
+            .build();
+
+    // When
+    boolean result = symbol.equals(symbol);
+
+    // Then
+    Assertions.assertTrue(result);
+  }
+
+  @Test
+  void equalsShouldNotEqualDifferent() {
+    // Given
+    TypeSymbol symbol1 = BasicSymbolsMill.typeSymbolBuilder()
+            .setName("Type1")
+            .setEnclosingScope(BasicSymbolsMill.scope())
+            .build();
+
+    TypeSymbol symbol2 = BasicSymbolsMill.typeSymbolBuilder()
+            .setName("Type2")
+            .setEnclosingScope(BasicSymbolsMill.scope())
+            .build();
+
+    // When
+    boolean result = symbol1.equals(symbol2);
+
+    // Then
+    Assertions.assertFalse(result);
+  }
+
+  @Test
+  void equalsShouldEqualSurrogate() {
+    // Given
+    IBasicSymbolsScope scope = BasicSymbolsMill.scope();
+
+    TypeSymbol symbol = BasicSymbolsMill.typeSymbolBuilder()
+            .setName("Type")
+            .setSpannedScope(BasicSymbolsMill.scope())
+            .build();
+
+    scope.add(symbol);
+
+    TypeSymbolSurrogate surrogate = BasicSymbolsMill.typeSymbolSurrogateBuilder()
+            .setName("Type")
+            .setEnclosingScope(scope)
+            .build();
+
+    // When
+    boolean result = symbol.equals(surrogate);
+
+    // Then
+    Assertions.assertTrue(result);
+  }
+
+  @Test
+  void equalsShouldNotEqualSurrogate() {
+    // Given
+    IBasicSymbolsScope scope = BasicSymbolsMill.scope();
+
+    TypeSymbol symbol = BasicSymbolsMill.typeSymbolBuilder()
+            .setName("Type1")
+            .setSpannedScope(BasicSymbolsMill.scope())
+            .build();
+
+    scope.add(symbol);
+
+    TypeSymbolSurrogate surrogate = BasicSymbolsMill.typeSymbolSurrogateBuilder()
+            .setName("Type2")
+            .setEnclosingScope(scope)
+            .build();
+
+    // When
+    boolean result = symbol.equals(surrogate);
+
+    // Then
+    Assertions.assertFalse(result);
+  }
+}

--- a/monticore-runtime/src/main/java/de/monticore/symboltable/ISymbol.java
+++ b/monticore-runtime/src/main/java/de/monticore/symboltable/ISymbol.java
@@ -10,6 +10,7 @@ import de.monticore.symboltable.stereotypes.IStereotypeReference;
 import de.monticore.symboltable.stereotypes.IStereotypeSymbol;
 import de.monticore.visitor.ITraverser;
 import de.se_rwth.commons.SourcePosition;
+import de.se_rwth.commons.Symbol;
 
 import java.util.*;
 
@@ -96,4 +97,7 @@ public interface ISymbol {
     visitor.handle(this);
   }
 
+  default ISymbol getThis() {
+    return this;
+  }
 }

--- a/monticore-runtime/src/main/java/de/monticore/symboltable/ISymbol.java
+++ b/monticore-runtime/src/main/java/de/monticore/symboltable/ISymbol.java
@@ -10,7 +10,6 @@ import de.monticore.symboltable.stereotypes.IStereotypeReference;
 import de.monticore.symboltable.stereotypes.IStereotypeSymbol;
 import de.monticore.visitor.ITraverser;
 import de.se_rwth.commons.SourcePosition;
-import de.se_rwth.commons.Symbol;
 
 import java.util.*;
 
@@ -97,7 +96,4 @@ public interface ISymbol {
     visitor.handle(this);
   }
 
-  default ISymbol getThis() {
-    return this;
-  }
 }


### PR DESCRIPTION
Symbols should be usable without knowing that surrogates exist. A surrogate therefore loads its delegate when needed to provide access to the members of the actual symbol. For `equals(Object)`, this was so far not the case. This merge request fixes this problem.

However, the fix is not straight forward. One may call `surrogate.equals(symbol)` or `symbol.equals(surrogate)` and in both cases the result should be true iff the delegate of the surrogate is the symbol. Furthermore, one has do consider that the symbol may be another surrogate. Therefore, `equals` of the symbol has to be adapted as well. 

The solution requires the use of `instance of`, which we would have like to avoid. However, its the most lightweight solution we found. Furthermore, equals is the one case where knowledge of surrogates affects a non-surrogate implementation.  