### PR TITLE
Fix non-determinism, remove hashset

### DIFF
--- a/monticore-runtime/src/main/java/de/monticore/symboltable/IScope.java
+++ b/monticore-runtime/src/main/java/de/monticore/symboltable/IScope.java
@@ -117,14 +117,12 @@ public interface IScope {
   }
 
   default <T extends ISymbol> Optional<T> getResolvedOrThrowException(final Collection<T> resolved) {
-    Set<T> resolvedSet = new HashSet<>(resolved);
-
-    if (resolvedSet.size() == 1) {
-      return Optional.of(resolvedSet.iterator().next());
-    } else if (resolvedSet.size() > 1) {
-      throw new ResolvedSeveralEntriesForSymbolException("0xA4095 Found " + resolvedSet.size()
-          + " symbols: " + resolvedSet.iterator().next().getFullName(),
-          resolvedSet);
+    if (resolved.size() == 1) {
+      return Optional.of(resolved.iterator().next());
+    } else if (resolved.size() > 1) {
+      throw new ResolvedSeveralEntriesForSymbolException("0xA4095 Found " + resolved.size()
+          + " symbols: " + resolved.iterator().next().getFullName(),
+              resolved);
     }
 
     return Optional.empty();


### PR DESCRIPTION
MontiCore's resolve mechanisms should behave deterministically. That is, return the same symbols in the same order on the same resolve calls. However, `getResolvedOrThrowException` uses a HashSet, potentially to remove duplicates, which results in a collection of symbols in arbitrary order. 

Removing duplicates is neither the task of that method nor is it needed. Methods that call this method already remove duplicates. Furthermore, the symbol table should be considered broken if local symbol lists contain duplicates.