### PR TITLE
Make UpdateChecker version parsing more robust

### DIFF
--- a/monticore-generator/src/main/java/de/monticore/cli/updateChecker/UpdateCheckerRunnable.java
+++ b/monticore-generator/src/main/java/de/monticore/cli/updateChecker/UpdateCheckerRunnable.java
@@ -1,18 +1,17 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.cli.updateChecker;
 
-import de.monticore.cli.updateChecker.HttpGetter;
 import de.se_rwth.commons.logging.Log;
 
-import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.Arrays;
+import java.io.StringReader;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class UpdateCheckerRunnable implements Runnable {
-
-  final protected static String REMOTE_PROPERTIES_PATH = "https://raw.githubusercontent.com/MontiCore/monticore/HEAD/gradle.properties";
+  
+  final protected static String REMOTE_PROPERTIES_PATH =
+      "https://raw.githubusercontent.com/MontiCore/monticore/HEAD/gradle.properties";
   final protected static String LOCAL_PROPERTIES_PATH = "/buildInfo.properties";
 
   protected String newVersion;
@@ -20,6 +19,7 @@ public class UpdateCheckerRunnable implements Runnable {
   protected HttpGetter httpGetter;
 
   protected static class Version {
+    
     protected final boolean snapshot;
     protected final int[] versionNumbers;
     protected final String versionString;
@@ -29,34 +29,50 @@ public class UpdateCheckerRunnable implements Runnable {
 
       snapshot = version.contains("SNAPSHOT");
 
-      String withoutSnapshot = version.replace("-SNAPSHOT", "");
-      String[] versionNumbersStrings = withoutSnapshot.split("\\.");
+      Pattern pattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)");
+      Matcher matcher = pattern.matcher(versionString);
 
-      versionNumbers = new int[]{0, 0, 0};
-      versionNumbers[0] = Integer.parseInt(versionNumbersStrings[0]);
-      versionNumbers[1] = Integer.parseInt(versionNumbersStrings[1]);
-      versionNumbers[2] = Integer.parseInt(versionNumbersStrings[2]);
+      if (matcher.find()) {
+        int major = Integer.parseInt(matcher.group(1));
+        int minor = Integer.parseInt(matcher.group(2));
+        int patch = Integer.parseInt(matcher.group(3));
+        
+        versionNumbers = new int[] { major, minor, patch };
+      }
+      else {
+        Log.warn("0xC4111: Could not parse version number: " + version);
+        versionNumbers = new int[] { 0, 0, 0 };
+      }
     }
 
     public boolean isOlderThan(Version other) {
-      if (this.versionNumbers[0] < other.versionNumbers[0]) return true;
-      else if (this.versionNumbers[0] > other.versionNumbers[0]) return false;
-
-      if (this.versionNumbers[1] < other.versionNumbers[1]) return true;
-      else if (this.versionNumbers[1] > other.versionNumbers[1]) return false;
-
-      if (this.versionNumbers[2] < other.versionNumbers[2]) return true;
-      else if (this.versionNumbers[2] > other.versionNumbers[2]) return false;
-
-      if (!this.snapshot && other.snapshot) return true;
-
-      return false;
+      if (this.versionNumbers[0] < other.versionNumbers[0]) {
+        return true;
+      }
+      else if (this.versionNumbers[0] > other.versionNumbers[0]) {
+        return false;
+      }
+      
+      if (this.versionNumbers[1] < other.versionNumbers[1]) {
+        return true;
+      }
+      else if (this.versionNumbers[1] > other.versionNumbers[1]) {
+        return false;
+      }
+      
+      if (this.versionNumbers[2] < other.versionNumbers[2]) {
+        return true;
+      }
+      else if (this.versionNumbers[2] > other.versionNumbers[2]) {
+        return false;
+      }
+      
+      return !this.snapshot && other.snapshot;
     }
-
+    
     public String getString() {
       return versionString;
     }
-
 
   }
 
@@ -84,7 +100,9 @@ public class UpdateCheckerRunnable implements Runnable {
     String localVersionString = local.getProperty("version");
     String remoteVersionString = remote.getProperty("version");
 
-    if (localVersionString == null || remoteVersionString == null) return false;
+    if (localVersionString == null || remoteVersionString == null) {
+      return false;
+    }
 
     Version localVersion = new Version(localVersionString);
     Version remoteVersion = new Version(remoteVersionString);
@@ -98,9 +116,8 @@ public class UpdateCheckerRunnable implements Runnable {
 
   @Override
   public void run() {
-    if(newVersionAvailable()) {
-      Log.info("0xA9001 There is a newer Version "
-          + newVersion
+    if (newVersionAvailable()) {
+      Log.info("0xA9001 There is a newer Version " + newVersion
           + " of this tool available at monticore.de/download", "");
     }
   }
@@ -112,7 +129,8 @@ public class UpdateCheckerRunnable implements Runnable {
 
     try {
       properties.load(new StringReader(raw));
-    } catch(Exception e) {
+    }
+    catch (Exception e) {
       Log.warn("0xA9002 Remote properties file is not a well defined properties file");
     }
 
@@ -124,8 +142,10 @@ public class UpdateCheckerRunnable implements Runnable {
 
     try {
       properties.load(this.getClass().getResourceAsStream(LOCAL_PROPERTIES_PATH));
-    } catch (Exception e) {
-      Log.debug("0xA9004 Could not find local properties file", UpdateCheckerRunnable.class.getName());
+    }
+    catch (Exception e) {
+      Log.debug("0xA9004 Could not find local properties file",
+          UpdateCheckerRunnable.class.getName());
     }
 
     return properties;


### PR DESCRIPTION
We use extended version strings to annotate special teaching versions of MontiCore, e.g. 7.9.0-sle26-SNAPSHOT.
With the old UpdateChecker, this resulted in an java.lang.NumberFormatException, as it tried to parse the last part "0-sle26" to an Integer.
The new implementation uses RegEx to clearly identify the correct version digits.