### PR TITLE
Lower spotbugs version to avoid junit dependency bug

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,5 +34,5 @@ commons_text_version=1.15.0
 freemarker_version=2.3.34
 guava_version=33.5.0-jre
 shadow_plugin_version=8.3.9
-spotbugs_annotations_version=4.9.8
+spotbugs_annotations_version=4.9.3
 checkerframework_version=3.54.0

--- a/monticore-generator/gradle.properties
+++ b/monticore-generator/gradle.properties
@@ -26,4 +26,4 @@ guava_version=33.5.0-jre
 shadow_plugin_version=8.3.9
 mockito_version=5.22.0
 groovy_version=5.0.4
-spotbugs_annotations_version=4.9.8
+spotbugs_annotations_version=4.9.3


### PR DESCRIPTION
Otherwise monticore-runtime has a transitive api dependency on junit-bom, which forces downstream projects to a specific JUnit version

See https://github.com/spotbugs/spotbugs/issues/3908