### PR TITLE
Fix test resource paths in monticore-grammar-emf

### DIFF
--- a/monticore-grammar-emf/build.gradle
+++ b/monticore-grammar-emf/build.gradle
@@ -29,28 +29,28 @@ dependencies {
     testImplementation testFixtures(project(':monticore-runtime'))
 }
 
-def srcDir = "$buildDir/main/java"
-def srcResourcesDir = "$buildDir/main/resources"
-def testDir = "$buildDir/test/java"
+def srcDir = layout.buildDirectory.dir("main/java")
+def srcResourcesDir = layout.buildDirectory.dir("main/resources")
+def testDir = layout.buildDirectory.dir("test/java")
 
-task copySrc(type: Copy) {
+tasks.register('copySrc', Copy) {
   from "${project(':monticore-grammar').projectDir}/src/main/java"
   into srcDir
 }
 
-task copySrcResources(type: Copy) {
-    from "${project(':monticore-grammar').projectDir}/src/main/resources"
-    into srcResourcesDir
+tasks.register('copySrcResources', Copy) {
+  from "${project(':monticore-grammar').projectDir}/src/main/resources"
+  into srcResourcesDir
 }
 
-task copyTest(type: Copy) {
+tasks.register('copyTest', Copy) {
   from "${project(':monticore-grammar').projectDir}/src/test/java"
   into testDir
 }
 
-task copyTestResources(type: Copy) {
-    from "${project(':monticore-grammar').projectDir}/src/test/resources"
-    into "$buildDir/test/resources"
+tasks.register('copyTestResources', Copy) {
+  from "${project(':monticore-grammar').projectDir}/src/test/resources"
+  into layout.buildDirectory.dir("test/resources")
 }
 
 def grammarDir = "${project(':monticore-grammar').projectDir}/src/main/grammars"
@@ -63,21 +63,21 @@ sourceSets {
                            "${project(':monticore-grammar').projectDir}/src/main/examples"]
 }
 
-task generate {}
+tasks.register('generate') {}
 
 tasks.named('generateMCGrammars') {
-  grammar.setFrom(file grammarDir)
+  grammar = file(grammarDir)
   script = "de/monticore/monticore_emf.groovy"
-  modelPath "${project(':monticore-grammar').projectDir}/src/main/grammars"
-  handcodedPath srcDir
+  modelPath = "${project(':monticore-grammar').projectDir}/src/main/grammars"
+  handWrittenCodeDir = files(srcDir)
   genINT = true
   dependsOn(copySrc, copyTest, copyTestResources)
 }
 
 generateTestMCGrammars {
   script = "de/monticore/monticore_emf.groovy"
-  modelPath("$grammarDir", "${project(':monticore-grammar').projectDir}/src/test/grammars", "${project(':monticore-grammar').projectDir}/src/main/examples")
-  handcodedPath(srcDir, testDir)
+  modelPath = files("$grammarDir", "${project(':monticore-grammar').projectDir}/src/test/grammars", "${project(':monticore-grammar').projectDir}/src/main/examples")
+  handWrittenCodeDir = files(srcDir, testDir)
   genINT = true
   dependsOn(copySrc, copyTest, copyTestResources)
 }

--- a/monticore-grammar-emf/build.gradle
+++ b/monticore-grammar-emf/build.gradle
@@ -84,19 +84,6 @@ generateTestMCGrammars {
 
 test {
   useJUnitPlatform()
-  exclude '**/CommentsOnASTTest.class'
-  exclude '**/SwitchStatementValidTest.class'
-  exclude '**/GrammarInheritanceCycleTest.class'
-  exclude '**/GrammarNameEqualsFileNameTest.class'
-  exclude '**/MCGrammarParserTest.class'
-  exclude '**/MCGrammarPrettyPrinterTest.class'
-  exclude '**/SynthesizeSymTypeFromMCBasicTypesTest.class'
-  exclude '**/SynthesizeSymTypeFromMCCollectionTypesTest.class'
-  exclude '**/SynthesizeSymTypeFromMCSimpleGenericTypesTest.class'
-  exclude '**/SynthesizeSymTypeFromMCFullGenericTypesTest.class'
-  exclude '**/SynthesizeSymTypeFromMCArrayTypesTest.class'
-  exclude '**/MCType2SymTypeExpressionTest.class'
-  exclude '**/ComponentTypeSymbolDeSerTest.class'
 }
 
 

--- a/monticore-grammar-emf/build.gradle
+++ b/monticore-grammar-emf/build.gradle
@@ -50,7 +50,7 @@ tasks.register('copyTest', Copy) {
 
 tasks.register('copyTestResources', Copy) {
   from "${project(':monticore-grammar').projectDir}/src/test/resources"
-  into layout.buildDirectory.dir("test/resources")
+  into layout.buildDirectory.dir("resources/test")
 }
 
 def grammarDir = "${project(':monticore-grammar').projectDir}/src/main/grammars"

--- a/monticore-grammar/src/test/java/de/monticore/comments/CommentsOnASTTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/comments/CommentsOnASTTest.java
@@ -39,7 +39,7 @@ public class CommentsOnASTTest {
 
   @Test
   public void testComments() throws IOException {
-    Optional<ASTJavaMethod> ast = parser.parse("src/test/resources/de/monticore/comments/CommentsTest.jlight");
+    Optional<ASTJavaMethod> ast = parser.parse("target/resources/test/de/monticore/comments/CommentsTest.jlight");
     assertTrue(ast.isPresent());
     assertFalse(parser.hasErrors());
 

--- a/monticore-grammar/src/test/java/de/monticore/grammar/GrammarGlobalScopeTestFactory.java
+++ b/monticore-grammar/src/test/java/de/monticore/grammar/GrammarGlobalScopeTestFactory.java
@@ -17,7 +17,6 @@ public class GrammarGlobalScopeTestFactory {
     // reset global scope
     scope.clear();
     scope.setFileExt("mc4");
-    scope.getSymbolPath().addEntry(Paths.get("src/test/resources"));
     scope.getSymbolPath().addEntry(Paths.get("target/resources/test"));
     return (Grammar_WithConceptsGlobalScope) scope;
   }

--- a/monticore-grammar/src/test/java/de/monticore/grammar/GrammarGlobalScopeTestFactory.java
+++ b/monticore-grammar/src/test/java/de/monticore/grammar/GrammarGlobalScopeTestFactory.java
@@ -18,7 +18,7 @@ public class GrammarGlobalScopeTestFactory {
     scope.clear();
     scope.setFileExt("mc4");
     scope.getSymbolPath().addEntry(Paths.get("src/test/resources"));
-    scope.getSymbolPath().addEntry(Paths.get("target/test/resources"));
+    scope.getSymbolPath().addEntry(Paths.get("target/resources/test"));
     return (Grammar_WithConceptsGlobalScope) scope;
   }
 

--- a/monticore-grammar/src/test/java/de/monticore/grammar/MCGrammarParserTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/grammar/MCGrammarParserTest.java
@@ -29,7 +29,7 @@ public class MCGrammarParserTest {
 
   @Test
   public void testParse() throws IOException {
-    String model = "src/test/resources/de/monticore/Statechart.mc4";
+    String model = "target/resources/test/de/monticore/Statechart.mc4";
 
     Grammar_WithConceptsParser parser =
         Grammar_WithConceptsMill.parser();
@@ -79,7 +79,7 @@ public class MCGrammarParserTest {
 
   @Test
   public void testScript() throws IOException {
-    String model = "src/test/resources/de/monticore/script/ScriptExample.mc4";
+    String model = "target/resources/test/de/monticore/script/ScriptExample.mc4";
 
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
     Optional<ASTMCGrammar> result = parser.parse(model);
@@ -91,7 +91,7 @@ public class MCGrammarParserTest {
 
   @Test
   public void testAutomatonV1() throws IOException {
-    String model = "src/test/resources/de/monticore/script/AutomatonV1.mc4";
+    String model = "target/resources/test/de/monticore/script/AutomatonV1.mc4";
 
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
     Optional<ASTMCGrammar> result = parser.parse(model);
@@ -103,7 +103,7 @@ public class MCGrammarParserTest {
 
   @Test
   public void testAutomatonV2() throws IOException {
-    String model = "src/test/resources/de/monticore/script/AutomatonV2.mc4";
+    String model = "target/resources/test/de/monticore/script/AutomatonV2.mc4";
 
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
     Optional<ASTMCGrammar> result = parser.parse(model);
@@ -115,7 +115,7 @@ public class MCGrammarParserTest {
 
   @Test
   public void testAutomatonV3() throws IOException {
-    String model = "src/test/resources/de/monticore/script/AutomatonV3.mc4";
+    String model = "target/resources/test/de/monticore/script/AutomatonV3.mc4";
 
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
     Optional<ASTMCGrammar> result = parser.parse(model);
@@ -125,7 +125,7 @@ public class MCGrammarParserTest {
 
   @Test
   public void testHierarchicalAutomaton() throws IOException {
-    String model = "src/test/resources/de/monticore/script/HierarchicalAutomaton.mc4";
+    String model = "target/resources/test/de/monticore/script/HierarchicalAutomaton.mc4";
 
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
     Optional<ASTMCGrammar> result = parser.parse(model);
@@ -137,7 +137,7 @@ public class MCGrammarParserTest {
 
   @Test
   public void testAutomatonWithInvsComp() throws IOException {
-    String model = "src/test/resources/de/monticore/script/AutomatonWithInvsComp.mc4";
+    String model = "target/resources/test/de/monticore/script/AutomatonWithInvsComp.mc4";
 
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
     Optional<ASTMCGrammar> result = parser.parse(model);
@@ -153,7 +153,7 @@ public class MCGrammarParserTest {
 
   @Test
   public void testAutomatonWithInvs() throws IOException {
-    String model = "src/test/resources/de/monticore/script/AutomatonWithInvs.mc4";
+    String model = "target/resources/test/de/monticore/script/AutomatonWithInvs.mc4";
 
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
     Optional<ASTMCGrammar> result = parser.parse(model);
@@ -163,7 +163,7 @@ public class MCGrammarParserTest {
 
   @Test
   public void testAutomatonWithInvsAndStartRule() throws IOException {
-    String model = "src/test/resources/de/monticore/script/AutomatonWithInvsAndStartRule.mc4";
+    String model = "target/resources/test/de/monticore/script/AutomatonWithInvsAndStartRule.mc4";
 
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
     Optional<ASTMCGrammar> result = parser.parse(model);
@@ -173,7 +173,7 @@ public class MCGrammarParserTest {
 
   @Test
   public void testGrammarSymbolTableInfo() throws IOException {
-    String model = "src/test/resources/Automaton.mc4";
+    String model = "target/resources/test/Automaton.mc4";
 
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
     Optional<ASTMCGrammar> result = parser.parse(model);
@@ -197,7 +197,7 @@ public class MCGrammarParserTest {
 
   @Test
   public void testPackageNameWithPointsDefined() throws IOException {
-    String model = "src/test/resources/de/monticore/point.in.packagename/PackagePathTest.mc4";
+    String model = "target/resources/test/de/monticore/point.in.packagename/PackagePathTest.mc4";
 
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
     parser.parse(model);
@@ -210,7 +210,7 @@ public class MCGrammarParserTest {
 
   @Test
   public void testPackageWrongPackageDefined() throws IOException {
-    String model = "src/test/resources/de/monticore/WrongPackage.mc4";
+    String model = "target/resources/test/de/monticore/WrongPackage.mc4";
 
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
     parser.parse(model);

--- a/monticore-grammar/src/test/java/de/monticore/grammar/MCGrammarPrettyPrinterTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/grammar/MCGrammarPrettyPrinterTest.java
@@ -32,7 +32,7 @@ public class MCGrammarPrettyPrinterTest {
   @Test
   // Test simple grammar
   public void testStatechart() throws IOException {
-    String model = "src/test/resources/de/monticore/Statechart.mc4";
+    String model = "target/resources/test/de/monticore/Statechart.mc4";
     
     // Parsing input
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
@@ -58,7 +58,7 @@ public class MCGrammarPrettyPrinterTest {
   @Test
   // Test grammar with symbols and scopes
   public void testAutomaton() throws IOException {
-    String model = "src/test/resources/Automaton.mc4";
+    String model = "target/resources/test/Automaton.mc4";
     
     // Parsing input
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
@@ -84,7 +84,7 @@ public class MCGrammarPrettyPrinterTest {
   @Test
   // Test grammar with symbols and scopes
   public void testGrammar() throws IOException {
-    String model = "src/test/resources/de/monticore/TestGrammar.mc4";
+    String model = "target/resources/test/de/monticore/TestGrammar.mc4";
 
     // Parsing input
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
@@ -110,7 +110,7 @@ public class MCGrammarPrettyPrinterTest {
   @Test
   // test lexicals with lexer commands and end actions
   public void testLexicals() throws IOException {
-    String model = "src/test/resources/de/monticore/common/TestLexicals.mc4";
+    String model = "target/resources/test/de/monticore/common/TestLexicals.mc4";
 
     // Parsing input
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
@@ -136,7 +136,7 @@ public class MCGrammarPrettyPrinterTest {
   @Test
   // test annotations
   public void testAnnotations() throws IOException {
-    String model = "src/test/resources/de/monticore/Annotations.mc4";
+    String model = "target/resources/test/de/monticore/Annotations.mc4";
 
     // Parsing input
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();

--- a/monticore-grammar/src/test/java/de/monticore/grammar/cocos/GrammarInheritanceCycleTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/grammar/cocos/GrammarInheritanceCycleTest.java
@@ -30,7 +30,7 @@ public class GrammarInheritanceCycleTest extends CocoTest {
   @Test
   public void testInvalid() throws IOException {
     Grammar_WithConceptsParser parser = new Grammar_WithConceptsParser();
-    Optional<ASTMCGrammar> grammar = parser.parse("src/test/resources/de/monticore/grammar/cocos/invalid/A4023/A4023.mc4");
+    Optional<ASTMCGrammar> grammar = parser.parse("target/resources/test/de/monticore/grammar/cocos/invalid/A4023/A4023.mc4");
 
     getFindings().clear();
     checker.checkAll(grammar.get());

--- a/monticore-grammar/src/test/java/de/monticore/grammar/cocos/GrammarNameEqualsFileNameTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/grammar/cocos/GrammarNameEqualsFileNameTest.java
@@ -23,7 +23,7 @@ public class GrammarNameEqualsFileNameTest extends CocoTest {
   @Test
   public void testInvalidFilename() throws IOException {
     Log.getFindings().clear();
-    parser.parse("src/test/resources/de/monticore/grammar/cocos/invalid/A4003/A4003.mc4");
+    parser.parse("target/resources/test/de/monticore/grammar/cocos/invalid/A4003/A4003.mc4");
 
     assertFalse(Log.getFindings().isEmpty());
     for(Finding f : Log.getFindings()){
@@ -35,7 +35,7 @@ public class GrammarNameEqualsFileNameTest extends CocoTest {
   @Test
   public void testInvalidPackage() throws IOException {
     Log.getFindings().clear();
-    parser.parse("src/test/resources/de/monticore/grammar/cocos/invalid/A4004/A4004.mc4");
+    parser.parse("target/resources/test/de/monticore/grammar/cocos/invalid/A4004/A4004.mc4");
 
     assertFalse(Log.getFindings().isEmpty());
     for(Finding f : Log.getFindings()){

--- a/monticore-grammar/src/test/java/de/monticore/javalight/cocos/JavaLightCocoTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/javalight/cocos/JavaLightCocoTest.java
@@ -50,7 +50,7 @@ public abstract class JavaLightCocoTest {
 
     globalScope = TestJavaLightMill.globalScope();
     globalScope.getSymbolPath().addEntry(Paths.get("src/test/resources"));
-    globalScope.getSymbolPath().addEntry(Paths.get("target/test/resources"));
+    globalScope.getSymbolPath().addEntry(Paths.get("target/resources/test"));
   }
 
   protected void testValid(String fileName, String methodName, JavaLightCoCoChecker checker) {

--- a/monticore-grammar/src/test/java/de/monticore/javalight/cocos/JavaLightCocoTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/javalight/cocos/JavaLightCocoTest.java
@@ -49,7 +49,6 @@ public abstract class JavaLightCocoTest {
     JavaLightTypeCheck3.init();
 
     globalScope = TestJavaLightMill.globalScope();
-    globalScope.getSymbolPath().addEntry(Paths.get("src/test/resources"));
     globalScope.getSymbolPath().addEntry(Paths.get("target/resources/test"));
   }
 

--- a/monticore-grammar/src/test/java/de/monticore/statements/cocos/SwitchStatementValidTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/statements/cocos/SwitchStatementValidTest.java
@@ -92,7 +92,7 @@ class SwitchStatementValidTest {
   void testSwitchEnumConstantsValid(String expr) throws IOException {
     // Given
     IMCCommonStatementsArtifactScope imported =
-      new MCCommonStatementsSymbols2Json().load("src/test/resources/de/monticore/statements/Enum.sym");
+      new MCCommonStatementsSymbols2Json().load("target/resources/test/de/monticore/statements/Enum.sym");
     TestMCCommonStatementsMill.globalScope().addSubScope(imported);
 
     VariableSymbol variable = TestMCCommonStatementsMill.variableSymbolBuilder()
@@ -123,7 +123,7 @@ class SwitchStatementValidTest {
   void testSwitchEnumConstantsInvalid(String expr, String error) throws IOException {
     // Given
     IMCCommonStatementsArtifactScope imported =
-      new MCCommonStatementsSymbols2Json().load("src/test/resources/de/monticore/statements/Enum.sym");
+      new MCCommonStatementsSymbols2Json().load("target/resources/test/de/monticore/statements/Enum.sym");
     TestMCCommonStatementsMill.globalScope().addSubScope(imported);
 
     VariableSymbol variable = TestMCCommonStatementsMill.variableSymbolBuilder()

--- a/monticore-grammar/src/test/java/de/monticore/symbols/compsymbols/_symboltable/ComponentTypeSymbolDeSerTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/symbols/compsymbols/_symboltable/ComponentTypeSymbolDeSerTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class ComponentTypeSymbolDeSerTest {
 
-  protected static final String RELATIVE_DIR = "src/test/resources/de/monticore/symbols/compsymbols/_symboltable/";
+  protected static final String RELATIVE_DIR = "target/resources/test/de/monticore/symbols/compsymbols/_symboltable/";
 
   protected ComponentTypeSymbolDeSer deSer;
   protected CompSymbolsSymbols2Json comp2json;

--- a/monticore-grammar/src/test/java/de/monticore/types/check/SynthesizeSymTypeFromMCArrayTypesTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/types/check/SynthesizeSymTypeFromMCArrayTypesTest.java
@@ -49,7 +49,7 @@ public class SynthesizeSymTypeFromMCArrayTypesTest {
     gs.add(DefsTypeBasic.type("Person"));
 
     CombineExpressionsWithLiteralsSymbols2Json symbols2Json = new CombineExpressionsWithLiteralsSymbols2Json();
-    ICombineExpressionsWithLiteralsArtifactScope as = symbols2Json.load("src/test/resources/de/monticore/types/check/Persondex.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as = symbols2Json.load("target/resources/test/de/monticore/types/check/Persondex.cesym");
     as.setEnclosingScope(gs);
   }
 

--- a/monticore-grammar/src/test/java/de/monticore/types/check/SynthesizeSymTypeFromMCBasicTypesTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/types/check/SynthesizeSymTypeFromMCBasicTypesTest.java
@@ -44,7 +44,7 @@ public class SynthesizeSymTypeFromMCBasicTypesTest {
     gs.add(DefsTypeBasic.type("Person"));
 
     CombineExpressionsWithLiteralsSymbols2Json symbols2Json = new CombineExpressionsWithLiteralsSymbols2Json();
-    ICombineExpressionsWithLiteralsArtifactScope as = symbols2Json.load("src/test/resources/de/monticore/types/check/Persondex.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as = symbols2Json.load("target/resources/test/de/monticore/types/check/Persondex.cesym");
     as.setEnclosingScope(gs);
   }
   

--- a/monticore-grammar/src/test/java/de/monticore/types/check/SynthesizeSymTypeFromMCCollectionTypesTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/types/check/SynthesizeSymTypeFromMCCollectionTypesTest.java
@@ -78,10 +78,10 @@ public class SynthesizeSymTypeFromMCCollectionTypesTest {
     gs.add(buildGeneric("Optional", "T"));
 
     CombineExpressionsWithLiteralsSymbols2Json symbols2Json = new CombineExpressionsWithLiteralsSymbols2Json();
-    ICombineExpressionsWithLiteralsArtifactScope as = symbols2Json.load("src/test/resources/de/monticore/types/check/Persondex.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as = symbols2Json.load("target/resources/test/de/monticore/types/check/Persondex.cesym");
     as.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as2 = symbols2Json.load("src/test/resources/de/monticore/types/check/Personaz.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as2 = symbols2Json.load("target/resources/test/de/monticore/types/check/Personaz.cesym");
     as2.setEnclosingScope(gs);
   }
 

--- a/monticore-grammar/src/test/java/de/monticore/types/check/SynthesizeSymTypeFromMCFullGenericTypesTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/types/check/SynthesizeSymTypeFromMCFullGenericTypesTest.java
@@ -57,19 +57,19 @@ public class SynthesizeSymTypeFromMCFullGenericTypesTest {
     gs.add(DefsTypeBasic.type("Void"));
 
     CombineExpressionsWithLiteralsSymbols2Json symbols2Json = new CombineExpressionsWithLiteralsSymbols2Json();
-    ICombineExpressionsWithLiteralsArtifactScope as = symbols2Json.load("src/test/resources/de/monticore/types/check/Persondex.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as = symbols2Json.load("target/resources/test/de/monticore/types/check/Persondex.cesym");
     as.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as2 = symbols2Json.load("src/test/resources/de/monticore/types/check/Personaz.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as2 = symbols2Json.load("target/resources/test/de/monticore/types/check/Personaz.cesym");
     as2.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as3 = symbols2Json.load("src/test/resources/de/monticore/types/check/Iterator.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as3 = symbols2Json.load("target/resources/test/de/monticore/types/check/Iterator.cesym");
     as3.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as4 = symbols2Json.load("src/test/resources/de/monticore/types/check/String.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as4 = symbols2Json.load("target/resources/test/de/monticore/types/check/String.cesym");
     as4.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as5 = symbols2Json.load("src/test/resources/de/monticore/types/check/Personjl.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as5 = symbols2Json.load("target/resources/test/de/monticore/types/check/Personjl.cesym");
     as5.setEnclosingScope(gs);
   }
 

--- a/monticore-grammar/src/test/java/de/monticore/types/check/SynthesizeSymTypeFromMCSimpleGenericTypesTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/types/check/SynthesizeSymTypeFromMCSimpleGenericTypesTest.java
@@ -52,19 +52,19 @@ public class SynthesizeSymTypeFromMCSimpleGenericTypesTest {
     gs.add(DefsTypeBasic.type("Void"));
 
     CombineExpressionsWithLiteralsSymbols2Json symbols2Json = new CombineExpressionsWithLiteralsSymbols2Json();
-    ICombineExpressionsWithLiteralsArtifactScope as = symbols2Json.load("src/test/resources/de/monticore/types/check/Persondex.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as = symbols2Json.load("target/resources/test/de/monticore/types/check/Persondex.cesym");
     as.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as2 = symbols2Json.load("src/test/resources/de/monticore/types/check/Personaz.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as2 = symbols2Json.load("target/resources/test/de/monticore/types/check/Personaz.cesym");
     as2.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as3 = symbols2Json.load("src/test/resources/de/monticore/types/check/Iterator.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as3 = symbols2Json.load("target/resources/test/de/monticore/types/check/Iterator.cesym");
     as3.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as4 = symbols2Json.load("src/test/resources/de/monticore/types/check/String.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as4 = symbols2Json.load("target/resources/test/de/monticore/types/check/String.cesym");
     as4.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as5 = symbols2Json.load("src/test/resources/de/monticore/types/check/Personjl.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as5 = symbols2Json.load("target/resources/test/de/monticore/types/check/Personjl.cesym");
     as5.setEnclosingScope(gs);
   }
   

--- a/monticore-grammar/src/test/java/de/monticore/types/helper/MCType2SymTypeExpressionTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/types/helper/MCType2SymTypeExpressionTest.java
@@ -53,28 +53,28 @@ public class MCType2SymTypeExpressionTest {
     gs.add(DefsTypeBasic.type("PersonValue"));
 
     CombineExpressionsWithLiteralsSymbols2Json symbols2Json = new CombineExpressionsWithLiteralsSymbols2Json();
-    ICombineExpressionsWithLiteralsArtifactScope as = symbols2Json.load("src/test/resources/de/monticore/types/check/PairA.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as = symbols2Json.load("target/resources/test/de/monticore/types/check/PairA.cesym");
     as.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as2 = symbols2Json.load("src/test/resources/de/monticore/types/check/PairB.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as2 = symbols2Json.load("target/resources/test/de/monticore/types/check/PairB.cesym");
     as2.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as3 = symbols2Json.load("src/test/resources/de/monticore/types/check/PairC.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as3 = symbols2Json.load("target/resources/test/de/monticore/types/check/PairC.cesym");
     as3.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as4 = symbols2Json.load("src/test/resources/de/monticore/types/check/Persondemc.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as4 = symbols2Json.load("target/resources/test/de/monticore/types/check/Persondemc.cesym");
     as4.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as5 = symbols2Json.load("src/test/resources/de/monticore/types/check/PersonKey.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as5 = symbols2Json.load("target/resources/test/de/monticore/types/check/PersonKey.cesym");
     as5.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as6 = symbols2Json.load("src/test/resources/de/monticore/types/check/PersonValue.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as6 = symbols2Json.load("target/resources/test/de/monticore/types/check/PersonValue.cesym");
     as6.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as7 = symbols2Json.load("src/test/resources/de/monticore/types/check/Pair.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as7 = symbols2Json.load("target/resources/test/de/monticore/types/check/Pair.cesym");
     as7.setEnclosingScope(gs);
 
-    ICombineExpressionsWithLiteralsArtifactScope as8 = symbols2Json.load("src/test/resources/de/monticore/types/check/Pair2.cesym");
+    ICombineExpressionsWithLiteralsArtifactScope as8 = symbols2Json.load("target/resources/test/de/monticore/types/check/Pair2.cesym");
     as8.setEnclosingScope(gs);
   }
 

--- a/monticore-libraries/javagen-runtime/build.gradle
+++ b/monticore-libraries/javagen-runtime/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 tasks.register('compileGenerator', JavaCompile) {
   source = sourceSets.generator.java
   classpath = sourceSets.generator.compileClasspath
-  destinationDir = file("${buildDir}/classes/generator")
+  destinationDirectory = layout.buildDirectory.dir("classes/generator")
   options.encoding = 'UTF-8'
 }
 


### PR DESCRIPTION
Some tests in `monticore-grammar` use models from the resource directory as input data.
In this case, the path to the original test resource directory (`src/test/resources/`) has been used.
However, during build the test resources are also automatically copied to `target/resources/test`.

The `monticore-grammar-emf` module copies large parts of the monticore-grammar project during build.
The target of the copy operation is inside this projects build directory (`target`).

During the `copyTestResources `task of the `monticore-grammar-emf` gradle configuration, the test resources were copied from `src/test/resources` to `target/test/resources`.
As a result, some tests used multiple input paths, while various tests were excluded in `monticore-grammar-emf`.

This pull request upgrades deprecated gradle syntax, updates the `copyTestResources` task to copy the test resources to the same location as in `monticore-grammar`. Finally, all affected tests are fixed and reenabled in `monticore-emf`. 