### PR TITLE
Add SymbolSupplier as a replacement to SymbolSurrogates

### DIFF
--- a/monticore-generator/src/main/java/de/monticore/MontiCoreScript.java
+++ b/monticore-generator/src/main/java/de/monticore/MontiCoreScript.java
@@ -739,6 +739,7 @@ public class MontiCoreScript extends Script implements GroovyRunner {
     ArtifactScopeClassDecorator artifactScopeDecorator = new ArtifactScopeClassDecorator(glex, symbolTableService, visitorService, methodDecorator);
     SymbolSurrogateDecorator symbolReferenceDecorator = new SymbolSurrogateDecorator(glex, symbolTableService, visitorService, methodDecorator, new MandatoryMutatorSymbolSurrogateDecorator(glex));
     SymbolSurrogateBuilderDecorator symbolReferenceBuilderDecorator = new SymbolSurrogateBuilderDecorator(glex, symbolTableService, accessorDecorator);
+    SymbolSupplierDecorator symbolSupplierDecorator = new SymbolSupplierDecorator(glex, symbolTableService);
     CommonSymbolInterfaceDecorator commonSymbolInterfaceDecorator = new CommonSymbolInterfaceDecorator(glex, symbolTableService, visitorService, methodDecorator);
     SymbolResolverInterfaceDecorator symbolResolverInterfaceDecorator = new SymbolResolverInterfaceDecorator(glex, symbolTableService);
     SymbolDeSerDecorator symbolDeSerDecorator = new SymbolDeSerDecorator(glex, symbolTableService, handCodedPath);
@@ -749,6 +750,7 @@ public class MontiCoreScript extends Script implements GroovyRunner {
 
     SymbolTableCDDecorator symbolTableCDDecorator = new SymbolTableCDDecorator(glex, handCodedPath, symbolTableService, symbolDecorator,
             symbolBuilderDecorator, symbolReferenceDecorator, symbolReferenceBuilderDecorator,
+            symbolSupplierDecorator,
             scopeInterfaceDecorator, scopeClassDecorator,
             globalScopeInterfaceDecorator, globalScopeClassDecorator,
             artifactScopeInterfaceDecorator, artifactScopeDecorator,

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/SymbolTableCDDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/SymbolTableCDDecorator.java
@@ -21,12 +21,7 @@ import de.monticore.codegen.cd2java._symboltable.scopesgenitor.ScopesGenitorDele
 import de.monticore.codegen.cd2java._symboltable.serialization.ScopeDeSerDecorator;
 import de.monticore.codegen.cd2java._symboltable.serialization.SymbolDeSerDecorator;
 import de.monticore.codegen.cd2java._symboltable.serialization.Symbols2JsonDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.CommonSymbolInterfaceDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolBuilderDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolResolverInterfaceDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolSurrogateBuilderDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolSurrogateDecorator;
+import de.monticore.codegen.cd2java._symboltable.symbol.*;
 import de.monticore.generating.templateengine.GlobalExtensionManagement;
 import de.monticore.io.paths.MCPath;
 import de.se_rwth.commons.Joiners;
@@ -53,6 +48,8 @@ public class SymbolTableCDDecorator extends AbstractDecorator {
   protected final SymbolSurrogateDecorator symbolReferenceDecorator;
 
   protected final SymbolSurrogateBuilderDecorator symbolReferenceBuilderDecorator;
+
+  protected final SymbolSupplierDecorator symbolSupplierDecorator;
 
   protected final SymbolTableService symbolTableService;
 
@@ -91,6 +88,7 @@ public class SymbolTableCDDecorator extends AbstractDecorator {
                                 final SymbolBuilderDecorator symbolBuilderDecorator,
                                 final SymbolSurrogateDecorator symbolReferenceDecorator,
                                 final SymbolSurrogateBuilderDecorator symbolReferenceBuilderDecorator,
+                                final SymbolSupplierDecorator symbolSupplierDecorator,
                                 final ScopeInterfaceDecorator scopeInterfaceDecorator,
                                 final ScopeClassDecorator scopeClassDecorator,
                                 final GlobalScopeInterfaceDecorator globalScopeInterfaceDecorator,
@@ -108,6 +106,7 @@ public class SymbolTableCDDecorator extends AbstractDecorator {
     this.symbolDecorator = symbolDecorator;
     this.symbolBuilderDecorator = symbolBuilderDecorator;
     this.symbolReferenceDecorator = symbolReferenceDecorator;
+    this.symbolSupplierDecorator = symbolSupplierDecorator;
     this.symbolTableService = symbolTableService;
     this.scopeInterfaceDecorator = scopeInterfaceDecorator;
     this.scopeClassDecorator = scopeClassDecorator;
@@ -148,6 +147,7 @@ public class SymbolTableCDDecorator extends AbstractDecorator {
     symbolTablePackage.addCDElement(createScopeInterface(scopeCD, symbolCD));
     symbolTablePackage.addAllCDElements(createSymbolReferenceClasses(symbolCD.getCDDefinition().getCDClassesList()));
     symbolTablePackage.addAllCDElements(createSymbolReferenceBuilderClasses(symbolCD.getCDDefinition().getCDClassesList()));
+    symbolTablePackage.addAllCDElements(createSymbolSupplierClasses(symbolCD.getCDDefinition().getCDClassesList()));
     symbolTablePackage.addAllCDElements(symbolDeSerList);
     symbolTablePackage.addCDElement(symbolTablePrinterClass);
     symbolTablePackage.addCDElement(createICommonSymbol(astCD));
@@ -227,6 +227,13 @@ public class SymbolTableCDDecorator extends AbstractDecorator {
         .stream()
         .map(symbolReferenceBuilderDecorator::decorate)
         .collect(Collectors.toList());
+  }
+
+  protected List<ASTCDClass> createSymbolSupplierClasses(List<ASTCDClass> symbolClasses) {
+    return symbolClasses
+            .stream()
+            .map(symbolSupplierDecorator::decorate)
+            .collect(Collectors.toList());
   }
 
   protected List<ASTCDInterface> createSymbolResolverInterfaces(List<? extends ASTCDType> astcdTypeList) {

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/SymbolTableConstants.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/SymbolTableConstants.java
@@ -44,6 +44,8 @@ public class SymbolTableConstants {
 
   public static final String SURROGATE_SUFFIX = "Surrogate";
 
+  public static final String SUPPLIER_SUFFIX = "Supplier";
+
   public static final String DE_SER_SUFFIX = "DeSer";
 
   public static final String SYMBOLS_2_JSON_SUFFIX = "Symbols2Json";

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/SymbolTableService.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/SymbolTableService.java
@@ -243,7 +243,6 @@ public class SymbolTableService extends AbstractService<SymbolTableService> {
   /**
    * symbol supplier class name, e.g. AutomatonSymbolSupplier
    */
-
   public String getSymbolSupplierSimpleName(ASTCDType astcdType) {
     return getSymbolSimpleName(astcdType) + SUPPLIER_SUFFIX;
   }

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/SymbolTableService.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/SymbolTableService.java
@@ -241,6 +241,14 @@ public class SymbolTableService extends AbstractService<SymbolTableService> {
   }
 
   /**
+   * symbol supplier class name, e.g. AutomatonSymbolSupplier
+   */
+
+  public String getSymbolSupplierSimpleName(ASTCDType astcdType) {
+    return getSymbolSimpleName(astcdType) + SUPPLIER_SUFFIX;
+  }
+
+  /**
    * resolving delegate symbol interface e.g. IAutomatonSymbolResolver
    */
 

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolSupplierDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/symbol/SymbolSupplierDecorator.java
@@ -1,0 +1,86 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.codegen.cd2java._symboltable.symbol;
+
+import de.monticore.cd4code.CD4CodeMill;
+import de.monticore.cd4codebasis._ast.ASTCDConstructor;
+import de.monticore.cd4codebasis._ast.ASTCDMethod;
+import de.monticore.cd4codebasis._ast.ASTCDParameter;
+import de.monticore.cdbasis._ast.ASTCDAttribute;
+import de.monticore.cdbasis._ast.ASTCDClass;
+import de.monticore.codegen.cd2java.AbstractCreator;
+import de.monticore.codegen.cd2java._symboltable.SymbolTableService;
+import de.monticore.generating.templateengine.GlobalExtensionManagement;
+import de.monticore.generating.templateengine.TemplateHookPoint;
+import de.monticore.umlmodifier._ast.ASTModifier;
+
+import static de.monticore.cd.codegen.CD2JavaTemplates.EMPTY_BODY;
+import static de.monticore.cd.facade.CDModifier.PROTECTED;
+import static de.monticore.cd.facade.CDModifier.PUBLIC;
+import static de.monticore.codegen.cd2java._symboltable.SymbolTableConstants.*;
+
+/**
+ * creates a SymbolLoader class from a grammar
+ */
+public class SymbolSupplierDecorator extends AbstractCreator<ASTCDClass, ASTCDClass> {
+
+  protected static final String TEMPLATE_PATH = "_symboltable.symbolsupplier.";
+  protected SymbolTableService symbolTableService;
+
+  public SymbolSupplierDecorator(final GlobalExtensionManagement glex,
+                                 final SymbolTableService symbolTableService) {
+    super(glex);
+    this.symbolTableService = symbolTableService;
+  }
+  
+  @Override
+  public ASTCDClass decorate(ASTCDClass symbolInput) {
+    String symbolSupplierSimpleName = symbolTableService.getSymbolSupplierSimpleName(symbolInput);
+    String scopeInterfaceType = symbolTableService.getScopeInterfaceFullName();
+    String symbolFullName = symbolTableService.getSymbolFullName(symbolInput);
+    String simpleName = symbolInput.getName();
+    ASTModifier modifier = symbolTableService.createModifierPublicModifier(symbolInput.getModifier());
+    
+    //name and enclosing scope methods do not delegate to the symbol
+
+    ASTCDAttribute nameAttribute = createNameAttribute();
+    ASTCDAttribute enclosingScopeAttribute = createEnclosingScopeAttribute(scopeInterfaceType);
+
+
+    return CD4CodeMill.cDClassBuilder()
+      .setName(symbolSupplierSimpleName)
+      .setModifier(modifier)
+      .setCDInterfaceUsage(CD4CodeMill.cDInterfaceUsageBuilder().addInterface(getMCTypeFacade().createBasicGenericTypeOf("de.monticore.symboltable.ISymbolSupplier", symbolTableService.getSymbolFullName(symbolInput))).build())
+      .addCDMember(createConstructor(symbolSupplierSimpleName, scopeInterfaceType))
+      .addCDMember(nameAttribute)
+      .addCDMember(enclosingScopeAttribute)
+      .addCDMember(createGetMethod(symbolSupplierSimpleName, symbolFullName, simpleName, scopeInterfaceType))
+      .build();
+  }
+
+  protected ASTCDConstructor createConstructor(String symbolSupplierClass, String scopeInterfaceType) {
+    ASTCDParameter nameParameter = getCDParameterFacade().createParameter(String.class, NAME_VAR);
+    ASTCDParameter enclosingScopeParameter = getCDParameterFacade().createParameter(scopeInterfaceType, ENCLOSING_SCOPE_VAR);
+    ASTCDConstructor constructor = getCDConstructorFacade().createConstructor(PUBLIC.build(), symbolSupplierClass, nameParameter, enclosingScopeParameter);
+    this.replaceTemplate(EMPTY_BODY, constructor, new TemplateHookPoint(TEMPLATE_PATH + "ConstructSymbolSupplier"));
+    return constructor;
+  }
+
+  protected ASTCDAttribute createNameAttribute() {
+    return getCDAttributeFacade().createAttribute(PROTECTED.build(), "String", "name");
+  }
+  
+  protected ASTCDAttribute createEnclosingScopeAttribute(String scopeType) {
+    return getCDAttributeFacade().createAttribute(PROTECTED.build(), scopeType, "enclosingScope");
+  }
+
+  protected ASTCDMethod createGetMethod(String symbolSupplierName, String symbolName, String simpleName, String scopeName) {
+    ASTCDMethod method = getCDMethodFacade().createMethod(PUBLIC.build(), getMCTypeFacade().createOptionalTypeOf(symbolName), "get");
+    String generatedError1 = symbolTableService.getGeneratedErrorCode("lazySymbolSupply1");
+    String generatedError2 = symbolTableService.getGeneratedErrorCode("lazySymbolSupply2");
+    this.replaceTemplate(EMPTY_BODY, method, new TemplateHookPoint(TEMPLATE_PATH + "GetSymbolSupplier", symbolSupplierName,
+      symbolName, simpleName, scopeName, generatedError1, generatedError2));
+    return method;
+  }
+
+
+}

--- a/monticore-generator/src/main/resources/_symboltable/symbolsupplier/ConstructSymbolSupplier.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/symbolsupplier/ConstructSymbolSupplier.ftl
@@ -1,0 +1,3 @@
+<#-- (c) https://github.com/MontiCore/monticore -->
+this.name = name;
+this.enclosingScope = enclosingScope;

--- a/monticore-generator/src/main/resources/_symboltable/symbolsupplier/GetSymbolSupplier.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/symbolsupplier/GetSymbolSupplier.ftl
@@ -1,19 +1,19 @@
 <#-- (c) https://github.com/MontiCore/monticore -->
-${tc.signature("symbolReferenceName", "symbolName", "simpelName", "scopeName", "generatedError1", "generatedError2")}
-    if (name == null || name.isEmpty()) throw new IllegalArgumentException("0xA4070${generatedError1} Symbol name may not be null or empty.");
+${tc.signature("symbolReferenceName", "symbolName", "simpleName", "scopeName", "generatedErrorEmpty", "generatedErrorScopeType")}
+    if (name == null || name.isEmpty()) throw new IllegalArgumentException("0xA4072${generatedErrorEmpty} Symbol name may not be null or empty.");
 
     Log.debug("Load full information of '" + name + "' (Kind " + "${symbolName}" + ").", ${symbolReferenceName}.class.getSimpleName());
     if(!(this.enclosingScope instanceof ${scopeName})){
-      Log.error("0xA4070${generatedError2} The enclosingScope needs to be a subtype of ${scopeName}.");
+      Log.error("0xA4073${generatedErrorScopeType} The enclosingScope needs to be a subtype of ${scopeName}.");
 			return Optional.empty();
     }
-    Optional<${symbolName}> resolvedSymbol = ((${scopeName}) enclosingScope).resolve${simpelName}(name);
+    Optional<${symbolName}> resolvedSymbol = ((${scopeName}) enclosingScope).resolve${simpleName}(name);
 
     if (resolvedSymbol.isPresent()) {
       Log.debug("Loaded full information of '" + name + "' successfully.",
       ${symbolReferenceName}.class.getSimpleName());
     } else {
-      Log.error("0xA1038 " + ${symbolReferenceName}.class.getSimpleName() + " Could not load full information of '" +
+      Log.error("0xA1037 " + ${symbolReferenceName}.class.getSimpleName() + " Could not load full information of '" +
         name + "' (Kind " + "${symbolName}" + ").");
     }
 		return resolvedSymbol;

--- a/monticore-generator/src/main/resources/_symboltable/symbolsupplier/GetSymbolSupplier.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/symbolsupplier/GetSymbolSupplier.ftl
@@ -1,0 +1,19 @@
+<#-- (c) https://github.com/MontiCore/monticore -->
+${tc.signature("symbolReferenceName", "symbolName", "simpelName", "scopeName", "generatedError1", "generatedError2")}
+    if (name == null || name.isEmpty()) throw new IllegalArgumentException("0xA4070${generatedError1} Symbol name may not be null or empty.");
+
+    Log.debug("Load full information of '" + name + "' (Kind " + "${symbolName}" + ").", ${symbolReferenceName}.class.getSimpleName());
+    if(!(this.enclosingScope instanceof ${scopeName})){
+      Log.error("0xA4070${generatedError2} The enclosingScope needs to be a subtype of ${scopeName}.");
+			return Optional.empty();
+    }
+    Optional<${symbolName}> resolvedSymbol = ((${scopeName}) enclosingScope).resolve${simpelName}(name);
+
+    if (resolvedSymbol.isPresent()) {
+      Log.debug("Loaded full information of '" + name + "' successfully.",
+      ${symbolReferenceName}.class.getSimpleName());
+    } else {
+      Log.error("0xA1038 " + ${symbolReferenceName}.class.getSimpleName() + " Could not load full information of '" +
+        name + "' (Kind " + "${symbolName}" + ").");
+    }
+		return resolvedSymbol;

--- a/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/SymbolTableCDDecoratorTest.java
+++ b/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/SymbolTableCDDecoratorTest.java
@@ -19,12 +19,7 @@ import de.monticore.codegen.cd2java._symboltable.scopesgenitor.ScopesGenitorDele
 import de.monticore.codegen.cd2java._symboltable.serialization.ScopeDeSerDecorator;
 import de.monticore.codegen.cd2java._symboltable.serialization.SymbolDeSerDecorator;
 import de.monticore.codegen.cd2java._symboltable.serialization.Symbols2JsonDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.CommonSymbolInterfaceDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolBuilderDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolResolverInterfaceDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolSurrogateBuilderDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolSurrogateDecorator;
+import de.monticore.codegen.cd2java._symboltable.symbol.*;
 import de.monticore.codegen.cd2java._symboltable.symbol.symbolsurrogatemutator.MandatoryMutatorSymbolSurrogateDecorator;
 import de.monticore.codegen.cd2java._visitor.VisitorService;
 import de.monticore.codegen.cd2java.methods.AccessorDecorator;
@@ -96,6 +91,7 @@ public class SymbolTableCDDecoratorTest extends DecoratorTestCase {
     ArtifactScopeClassDecorator artifactScopeDecorator = new ArtifactScopeClassDecorator(glex, symbolTableService, visitorService, methodDecorator);
     SymbolSurrogateDecorator symbolReferenceDecorator = new SymbolSurrogateDecorator(glex, symbolTableService, visitorService, methodDecorator, new MandatoryMutatorSymbolSurrogateDecorator(glex));
     SymbolSurrogateBuilderDecorator symbolReferenceBuilderDecorator = new SymbolSurrogateBuilderDecorator(glex, symbolTableService, accessorDecorator);
+    SymbolSupplierDecorator symbolSupplierDecorator = new SymbolSupplierDecorator(glex, symbolTableService);
     CommonSymbolInterfaceDecorator commonSymbolInterfaceDecorator = new CommonSymbolInterfaceDecorator(glex, symbolTableService, visitorService, methodDecorator);
     SymbolResolverInterfaceDecorator symbolResolverInterfaceDecorator = new SymbolResolverInterfaceDecorator(glex, symbolTableService);
     SymbolDeSerDecorator symbolDeSerDecorator = new SymbolDeSerDecorator(glex, symbolTableService, new MCPath());
@@ -106,6 +102,7 @@ public class SymbolTableCDDecoratorTest extends DecoratorTestCase {
 
     SymbolTableCDDecorator symbolTableCDDecorator = new SymbolTableCDDecorator(glex, targetPath, symbolTableService, symbolDecorator,
         symbolBuilderDecorator, symbolReferenceDecorator, symbolReferenceBuilderDecorator,
+        symbolSupplierDecorator,
         scopeInterfaceDecorator, scopeClassDecorator,
         globalScopeInterfaceDecorator, globalScopeClassDecorator,
         artifactScopeInterfaceDecorator, artifactScopeDecorator,
@@ -122,6 +119,7 @@ public class SymbolTableCDDecoratorTest extends DecoratorTestCase {
     SymbolTableService mockService = Mockito.spy(new SymbolTableService(originalASTCompilationUnit));
     SymbolTableCDDecorator mockDecorator = new SymbolTableCDDecorator(glex, targetPath, mockService, symbolDecorator,
         symbolBuilderDecorator, symbolReferenceDecorator, symbolReferenceBuilderDecorator,
+        symbolSupplierDecorator,
         scopeInterfaceDecorator, scopeClassDecorator,
         globalScopeInterfaceDecorator, globalScopeClassDecorator,
         artifactScopeInterfaceDecorator, artifactScopeDecorator,
@@ -152,7 +150,7 @@ public class SymbolTableCDDecoratorTest extends DecoratorTestCase {
 
   @Test
   public void testClassCount() {
-    assertEquals(27, symTabCD.getCDDefinition().getCDClassesList().size());
+    assertEquals(31, symTabCD.getCDDefinition().getCDClassesList().size());
   
     assertTrue(Log.getFindings().isEmpty());
   }
@@ -235,30 +233,33 @@ public class SymbolTableCDDecoratorTest extends DecoratorTestCase {
 
   @Test
   public void testClassCountWithHC() {
-    assertEquals(27, symTabCDWithHC.getCDDefinition().getCDClassesList().size());
+    assertEquals(31, symTabCDWithHC.getCDDefinition().getCDClassesList().size());
   
     assertTrue(Log.getFindings().isEmpty());
   }
 
   @Test
   public void testClassNamesWithHC() {
-    ASTCDClass automatonSymbol = getClassBy("AutomatonSymbol", symTabCDWithHC);
-    ASTCDClass stateSymbol = getClassBy("StateSymbol", symTabCDWithHC);
-    ASTCDClass fooSymbol = getClassBy("FooSymbol", symTabCDWithHC);
-    ASTCDClass automatonSymbolBuilder = getClassBy("AutomatonSymbolBuilder", symTabCDWithHC);
-    ASTCDClass stateSymbolBuilder = getClassBy("StateSymbolBuilder", symTabCDWithHC);
-    ASTCDClass fooSymbolBuilder = getClassBy("FooSymbolBuilder", symTabCDWithHC);
-    ASTCDClass automatonScope = getClassBy("AutomatonScope", symTabCDWithHC);
-    ASTCDClass automatonSymbolSurrogate = getClassBy("AutomatonSymbolSurrogate", symTabCDWithHC);
-    ASTCDClass stateSymbolSurrogate = getClassBy("StateSymbolSurrogate", symTabCDWithHC);
-    ASTCDClass fooSymbolSurrogate = getClassBy("FooSymbolSurrogate", symTabCDWithHC);
-    ASTCDClass automatonSymbolSurrogateBuilder = getClassBy("AutomatonSymbolSurrogateBuilder", symTabCDWithHC);
-    ASTCDClass stateSymbolSurrogateBuilder = getClassBy("StateSymbolSurrogateBuilder", symTabCDWithHC);
-    ASTCDClass fooSymbolSurrogateBuilder = getClassBy("FooSymbolSurrogateBuilder", symTabCDWithHC);
-    ASTCDClass automatonGlobalScope = getClassBy("AutomatonGlobalScope", symTabCDWithHC);
-    ASTCDClass automatonArtifactScope = getClassBy("AutomatonArtifactScope", symTabCDWithHC);
-    ASTCDClass automatonScopesGenitor = getClassBy("AutomatonScopesGenitor", symTabCDWithHC);
-    ASTCDClass automatonScopesGenitorDelegator = getClassBy("AutomatonScopesGenitorDelegator", symTabCDWithHC);
+    getClassBy("AutomatonSymbol", symTabCDWithHC);
+    getClassBy("StateSymbol", symTabCDWithHC);
+    getClassBy("FooSymbol", symTabCDWithHC);
+    getClassBy("AutomatonSymbolBuilder", symTabCDWithHC);
+    getClassBy("StateSymbolBuilder", symTabCDWithHC);
+    getClassBy("FooSymbolBuilder", symTabCDWithHC);
+    getClassBy("AutomatonScope", symTabCDWithHC);
+    getClassBy("AutomatonSymbolSurrogate", symTabCDWithHC);
+    getClassBy("AutomatonSymbolSupplier", symTabCDWithHC);
+    getClassBy("StateSymbolSurrogate", symTabCDWithHC);
+    getClassBy("StateSymbolSupplier", symTabCDWithHC);
+    getClassBy("FooSymbolSurrogate", symTabCDWithHC);
+    getClassBy("FooSymbolSupplier", symTabCDWithHC);
+    getClassBy("AutomatonSymbolSurrogateBuilder", symTabCDWithHC);
+    getClassBy("StateSymbolSurrogateBuilder", symTabCDWithHC);
+    getClassBy("FooSymbolSurrogateBuilder", symTabCDWithHC);
+    getClassBy("AutomatonGlobalScope", symTabCDWithHC);
+    getClassBy("AutomatonArtifactScope", symTabCDWithHC);
+    getClassBy("AutomatonScopesGenitor", symTabCDWithHC);
+    getClassBy("AutomatonScopesGenitorDelegator", symTabCDWithHC);
   
     assertTrue(Log.getFindings().isEmpty());
   }
@@ -299,7 +300,7 @@ public class SymbolTableCDDecoratorTest extends DecoratorTestCase {
 
   @Test
   public void testClassCountComponent() {
-    assertEquals(27, symTabCDComponent.getCDDefinition().getCDClassesList().size());
+    assertEquals(31, symTabCDComponent.getCDDefinition().getCDClassesList().size());
   
     assertTrue(Log.getFindings().isEmpty());
   }

--- a/monticore-generator/src/test/java/de/monticore/codegen/cd2java/mill/CDMillDecoratorTest.java
+++ b/monticore-generator/src/test/java/de/monticore/codegen/cd2java/mill/CDMillDecoratorTest.java
@@ -34,12 +34,7 @@ import de.monticore.codegen.cd2java._symboltable.scopesgenitor.ScopesGenitorDele
 import de.monticore.codegen.cd2java._symboltable.serialization.ScopeDeSerDecorator;
 import de.monticore.codegen.cd2java._symboltable.serialization.SymbolDeSerDecorator;
 import de.monticore.codegen.cd2java._symboltable.serialization.Symbols2JsonDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.CommonSymbolInterfaceDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolBuilderDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolResolverInterfaceDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolSurrogateBuilderDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolSurrogateDecorator;
+import de.monticore.codegen.cd2java._symboltable.symbol.*;
 import de.monticore.codegen.cd2java._symboltable.symbol.symbolsurrogatemutator.MandatoryMutatorSymbolSurrogateDecorator;
 import de.monticore.codegen.cd2java._visitor.VisitorService;
 import de.monticore.codegen.cd2java.data.DataDecorator;
@@ -136,6 +131,7 @@ public class CDMillDecoratorTest extends DecoratorTestCase {
     ArtifactScopeClassDecorator artifactScopeDecorator = new ArtifactScopeClassDecorator(glex, symbolTableService, visitorService, methodDecorator);
     SymbolSurrogateDecorator symbolReferenceDecorator = new SymbolSurrogateDecorator(glex, symbolTableService, visitorService, methodDecorator, new MandatoryMutatorSymbolSurrogateDecorator(glex));
     SymbolSurrogateBuilderDecorator symbolReferenceBuilderDecorator = new SymbolSurrogateBuilderDecorator(glex, symbolTableService, accessorDecorator);
+    SymbolSupplierDecorator symbolSupplierDecorator = new SymbolSupplierDecorator(glex, symbolTableService);
     CommonSymbolInterfaceDecorator commonSymbolInterfaceDecorator = new CommonSymbolInterfaceDecorator(glex, symbolTableService, visitorService, methodDecorator);
     SymbolResolverInterfaceDecorator symbolResolverInterfaceDecorator = new SymbolResolverInterfaceDecorator(glex, symbolTableService);
     SymbolDeSerDecorator symbolDeSerDecorator = new SymbolDeSerDecorator(glex, symbolTableService, new MCPath());
@@ -148,6 +144,7 @@ public class CDMillDecoratorTest extends DecoratorTestCase {
 
     SymbolTableCDDecorator symbolTableCDDecorator = new SymbolTableCDDecorator(glex, targetPath, symbolTableService, symbolDecorator,
         symbolBuilderDecorator, symbolReferenceDecorator, symbolReferenceBuilderDecorator,
+        symbolSupplierDecorator,
         scopeInterfaceDecorator, scopeClassDecorator,
         globalScopeInterfaceDecorator, globalScopeClassDecorator,
         artifactScopeInterfaceDecorator, artifactScopeDecorator,

--- a/monticore-generator/src/test/java/de/monticore/codegen/cd2java/mill/MillDecoratorTest.java
+++ b/monticore-generator/src/test/java/de/monticore/codegen/cd2java/mill/MillDecoratorTest.java
@@ -42,12 +42,7 @@ import de.monticore.codegen.cd2java._symboltable.scopesgenitor.ScopesGenitorDele
 import de.monticore.codegen.cd2java._symboltable.serialization.ScopeDeSerDecorator;
 import de.monticore.codegen.cd2java._symboltable.serialization.SymbolDeSerDecorator;
 import de.monticore.codegen.cd2java._symboltable.serialization.Symbols2JsonDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.CommonSymbolInterfaceDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolBuilderDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolResolverInterfaceDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolSurrogateBuilderDecorator;
-import de.monticore.codegen.cd2java._symboltable.symbol.SymbolSurrogateDecorator;
+import de.monticore.codegen.cd2java._symboltable.symbol.*;
 import de.monticore.codegen.cd2java._symboltable.symbol.symbolsurrogatemutator.MandatoryMutatorSymbolSurrogateDecorator;
 import de.monticore.codegen.cd2java._visitor.CDTraverserDecorator;
 import de.monticore.codegen.cd2java._visitor.HandlerDecorator;
@@ -187,6 +182,7 @@ public class MillDecoratorTest extends DecoratorTestCase {
     ArtifactScopeClassDecorator artifactScopeDecorator = new ArtifactScopeClassDecorator(glex, symbolTableService, visitorService, methodDecorator);
     SymbolSurrogateDecorator symbolReferenceDecorator = new SymbolSurrogateDecorator(glex, symbolTableService, visitorService, methodDecorator, new MandatoryMutatorSymbolSurrogateDecorator(glex));
     SymbolSurrogateBuilderDecorator symbolReferenceBuilderDecorator = new SymbolSurrogateBuilderDecorator(glex, symbolTableService, accessorDecorator);
+    SymbolSupplierDecorator symbolSupplierDecorator = new SymbolSupplierDecorator(glex, symbolTableService);
     CommonSymbolInterfaceDecorator commonSymbolInterfaceDecorator = new CommonSymbolInterfaceDecorator(glex, symbolTableService, visitorService, methodDecorator);
     SymbolResolverInterfaceDecorator symbolResolverInterfaceDecorator = new SymbolResolverInterfaceDecorator(glex, symbolTableService);
     SymbolDeSerDecorator symbolDeSerDecorator = new SymbolDeSerDecorator(glex, symbolTableService, new MCPath());
@@ -199,6 +195,7 @@ public class MillDecoratorTest extends DecoratorTestCase {
 
     SymbolTableCDDecorator symbolTableCDDecorator = new SymbolTableCDDecorator(glex, targetPath, symbolTableService, symbolDecorator,
         symbolBuilderDecorator, symbolReferenceDecorator, symbolReferenceBuilderDecorator,
+        symbolSupplierDecorator,
         scopeInterfaceDecorator, scopeClassDecorator,
         globalScopeInterfaceDecorator, globalScopeClassDecorator,
         artifactScopeInterfaceDecorator, artifactScopeDecorator,

--- a/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/GrammarScopesGenitor.java
+++ b/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/GrammarScopesGenitor.java
@@ -296,24 +296,7 @@ public class GrammarScopesGenitor extends GrammarScopesGenitorTOP {
 
       IGrammarScope enclosingScope = getCurrentScope().orElse(null);
 
-      grammarSymbol.addSuperGrammarSupplier(() -> {
-        // TODO: This code is currently generated: TODO: generate a supplier?
-        Log.debug("Load full information of '" + superGrammarName + "' (Kind " + "de.monticore.grammar.grammar._symboltable.MCGrammarSymbol" + ").", MCGrammarSymbolSurrogate.class.getSimpleName());
-        if(!(enclosingScope instanceof de.monticore.grammar.grammar._symboltable.IGrammarScope)){
-          Log.error("0xA4070x84660 The enclosingScope needs to be a subtype of de.monticore.grammar.grammar._symboltable.IGrammarScope.");
-        }
-        Optional<de.monticore.grammar.grammar._symboltable.MCGrammarSymbol> resolvedSymbol = ((de.monticore.grammar.grammar._symboltable.IGrammarScope) enclosingScope).resolveMCGrammar(superGrammarName);
-
-        if (resolvedSymbol.isPresent()) {
-          Log.debug("Loaded full information of '" + superGrammarName + "' successfully.",
-                  MCGrammarSymbolSurrogate.class.getSimpleName());
-          return resolvedSymbol.get();
-        } else {
-          Log.error("0xA1038 " + MCGrammarSymbolSurrogate.class.getSimpleName() + " Could not load full information of '" +
-                  superGrammarName + "' (Kind " + "de.monticore.grammar.grammar._symboltable.MCGrammarSymbol" + ").");
-          return null;
-        }
-      });
+      grammarSymbol.addSuperGrammarSupplier(GrammarSymbolSupplier.memoize(new GrammarSymbolSupplier(superGrammarName, enclosingScope)));
     }
   }
 

--- a/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/GrammarScopesGenitor.java
+++ b/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/GrammarScopesGenitor.java
@@ -294,11 +294,26 @@ public class GrammarScopesGenitor extends GrammarScopesGenitorTOP {
     for (ASTGrammarReference ref : astGrammar.getSupergrammarList()) {
       final String superGrammarName = getQualifiedName(ref.getNameList());
 
-      final MCGrammarSymbolSurrogate superGrammar = new MCGrammarSymbolSurrogate(
-          superGrammarName);
-      superGrammar.setEnclosingScope(getCurrentScope().orElse(null));
+      IGrammarScope enclosingScope = getCurrentScope().orElse(null);
 
-      grammarSymbol.addSuperGrammar(superGrammar);
+      grammarSymbol.addSuperGrammarSupplier(() -> {
+        // TODO: This code is currently generated: TODO: generate a supplier?
+        Log.debug("Load full information of '" + superGrammarName + "' (Kind " + "de.monticore.grammar.grammar._symboltable.MCGrammarSymbol" + ").", MCGrammarSymbolSurrogate.class.getSimpleName());
+        if(!(enclosingScope instanceof de.monticore.grammar.grammar._symboltable.IGrammarScope)){
+          Log.error("0xA4070x84660 The enclosingScope needs to be a subtype of de.monticore.grammar.grammar._symboltable.IGrammarScope.");
+        }
+        Optional<de.monticore.grammar.grammar._symboltable.MCGrammarSymbol> resolvedSymbol = ((de.monticore.grammar.grammar._symboltable.IGrammarScope) enclosingScope).resolveMCGrammar(superGrammarName);
+
+        if (resolvedSymbol.isPresent()) {
+          Log.debug("Loaded full information of '" + superGrammarName + "' successfully.",
+                  MCGrammarSymbolSurrogate.class.getSimpleName());
+          return resolvedSymbol.get();
+        } else {
+          Log.error("0xA1038 " + MCGrammarSymbolSurrogate.class.getSimpleName() + " Could not load full information of '" +
+                  superGrammarName + "' (Kind " + "de.monticore.grammar.grammar._symboltable.MCGrammarSymbol" + ").");
+          return null;
+        }
+      });
     }
   }
 

--- a/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/GrammarSymbolSupplier.java
+++ b/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/GrammarSymbolSupplier.java
@@ -1,0 +1,53 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.grammar.grammar._symboltable;
+
+import de.se_rwth.commons.logging.Log;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+// TODO: Remove this class after version 7.9.0 (as it is generated)
+public class GrammarSymbolSupplier implements Supplier<Optional<MCGrammarSymbol>> {
+  protected final String qualifiedName;
+  protected final IGrammarScope enclosingScope;
+
+  public GrammarSymbolSupplier(String qualifiedName, IGrammarScope enclosingScope) {
+    this.enclosingScope = enclosingScope;
+    this.qualifiedName = qualifiedName;
+  }
+
+  @Override
+  public Optional<MCGrammarSymbol> get() {
+    Log.debug("Load full information of '" + qualifiedName + "' (Kind " + "de.monticore.grammar.grammar._symboltable.MCGrammarSymbol" + ").", MCGrammarSymbolSurrogate.class.getSimpleName());
+    if(!(enclosingScope instanceof de.monticore.grammar.grammar._symboltable.IGrammarScope)){
+      Log.error("0xA4070x84660 The enclosingScope needs to be a subtype of de.monticore.grammar.grammar._symboltable.IGrammarScope.");
+      return Optional.empty();
+    }
+    Optional<MCGrammarSymbol> resolvedSymbol = ((de.monticore.grammar.grammar._symboltable.IGrammarScope) enclosingScope).resolveMCGrammar(qualifiedName);
+
+    if (resolvedSymbol.isPresent()) {
+      Log.debug("Loaded full information of '" + qualifiedName + "' successfully.",
+                GrammarSymbolSupplier.class.getSimpleName());
+      return resolvedSymbol;
+    } else {
+      Log.error("0xA1038 " + GrammarSymbolSupplier.class.getSimpleName() + " Could not load full information of '" +
+                        qualifiedName + "' (Kind " + "de.monticore.grammar.grammar._symboltable.MCGrammarSymbol" + ").");
+      return resolvedSymbol;
+    }
+  }
+
+  // TODO: Move me elsewhere
+  public static <T> Supplier<T> memoize(Supplier<T> delegate) {
+    AtomicReference<T> value = new AtomicReference<>();
+    return () -> {
+      T val = value.get();
+      if (val == null) {
+        val = value.updateAndGet(cur -> cur == null ?
+                Objects.requireNonNull(delegate.get()) : cur);
+      }
+      return val;
+    };
+  }
+}

--- a/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/GrammarSymbolSupplier.java
+++ b/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/GrammarSymbolSupplier.java
@@ -20,9 +20,9 @@ public class GrammarSymbolSupplier implements Supplier<Optional<MCGrammarSymbol>
 
   @Override
   public Optional<MCGrammarSymbol> get() {
-    Log.debug("Load full information of '" + qualifiedName + "' (Kind " + "de.monticore.grammar.grammar._symboltable.MCGrammarSymbol" + ").", MCGrammarSymbolSurrogate.class.getSimpleName());
+    Log.debug("Load full information of '" + qualifiedName + "' (Kind " + "de.monticore.grammar.grammar._symboltable.MCGrammarSymbol" + ").", GrammarSymbolSupplier.class.getSimpleName());
     if(!(enclosingScope instanceof de.monticore.grammar.grammar._symboltable.IGrammarScope)){
-      Log.error("0xA4070x84660 The enclosingScope needs to be a subtype of de.monticore.grammar.grammar._symboltable.IGrammarScope.");
+      Log.error("0xA4073x84660 The enclosingScope needs to be a subtype of de.monticore.grammar.grammar._symboltable.IGrammarScope.");
       return Optional.empty();
     }
     Optional<MCGrammarSymbol> resolvedSymbol = ((de.monticore.grammar.grammar._symboltable.IGrammarScope) enclosingScope).resolveMCGrammar(qualifiedName);
@@ -32,13 +32,12 @@ public class GrammarSymbolSupplier implements Supplier<Optional<MCGrammarSymbol>
                 GrammarSymbolSupplier.class.getSimpleName());
       return resolvedSymbol;
     } else {
-      Log.error("0xA1038 " + GrammarSymbolSupplier.class.getSimpleName() + " Could not load full information of '" +
+      Log.error("0xA1037 " + GrammarSymbolSupplier.class.getSimpleName() + " Could not load full information of '" +
                         qualifiedName + "' (Kind " + "de.monticore.grammar.grammar._symboltable.MCGrammarSymbol" + ").");
       return resolvedSymbol;
     }
   }
 
-  // TODO: Move me elsewhere
   public static <T> Supplier<T> memoize(Supplier<T> delegate) {
     AtomicReference<T> value = new AtomicReference<>();
     return () -> {

--- a/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/IGrammarScope.java
+++ b/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/IGrammarScope.java
@@ -63,8 +63,7 @@ public interface IGrammarScope extends IGrammarScopeTOP {
     Optional<MCGrammarSymbol> spanningSymbol = MCGrammarSymbolTableHelper.getMCGrammarSymbol(this);
     if (spanningSymbol.isPresent()) {
       MCGrammarSymbol grammarSymbol = spanningSymbol.get();
-      for (MCGrammarSymbolSurrogate superGrammarRef : grammarSymbol.getSuperGrammars()) {
-        final MCGrammarSymbol superGrammar = superGrammarRef.lazyLoadDelegate();
+      for (MCGrammarSymbol superGrammar : grammarSymbol.getSuperGrammarSymbols()) {
         resolvedSymbol = resolveInSuperGrammar(name, superGrammar);
         // Stop as soon as symbol is found in a super grammar.
         if (resolvedSymbol.isPresent()) {

--- a/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/MCGrammarSymbol.java
+++ b/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/MCGrammarSymbol.java
@@ -14,6 +14,8 @@ import de.monticore.grammar.grammar._ast.ASTMCGrammar;
 import de.se_rwth.commons.Names;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import static com.google.common.collect.ImmutableList.copyOf;
 import static java.util.Optional.ofNullable;
@@ -23,7 +25,7 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
 
   public static final String DEFAULT_MODE = "DEFAULT_MODE";
 
-  protected final List<MCGrammarSymbolSurrogate> superGrammars = new ArrayList<>();
+  protected final List<Supplier<MCGrammarSymbol>> superGrammars = new ArrayList<>();
 
   protected Map<String, Collection<String>> tokenModes = Maps.newHashMap();
 
@@ -63,14 +65,17 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
     return ofNullable(startProd);
   }
 
-  public List<MCGrammarSymbolSurrogate> getSuperGrammars() {
-    return copyOf(superGrammars);
+  /**
+   * With the (planned) removal of SymbolSurrogates, real symbols are already returned
+   * @deprecated {@link #getSuperGrammarSymbols()}
+   */
+  @Deprecated
+  public List<MCGrammarSymbol> getSuperGrammars() {
+    return this.getSuperGrammarSymbols();
   }
 
   public List<MCGrammarSymbol> getSuperGrammarSymbols() {
-    return copyOf(superGrammars.stream()
-            .map(g -> g.lazyLoadDelegate())
-            .collect(toList()));
+    return superGrammars.stream().map(Supplier::get).collect(toList());
   }
 
   public List<MCGrammarSymbol> getAllSuperGrammars() {
@@ -83,8 +88,12 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
     return copyOf(supGrammars);
   }
 
-  public void addSuperGrammar(MCGrammarSymbolSurrogate superGrammarRef) {
+  public void addSuperGrammar(Supplier<MCGrammarSymbol> superGrammarRef) {
     this.superGrammars.add(Preconditions.checkNotNull(superGrammarRef));
+  }
+
+  public void addSuperGrammarSupplier(Supplier<MCGrammarSymbol> superGrammarRef) {
+    this.superGrammars.add(memoize(Preconditions.checkNotNull(superGrammarRef)));
   }
 
   public Collection<ProdSymbol> getProds() {
@@ -115,7 +124,7 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
     final Map<String, ProdSymbol> map = new LinkedHashMap<>();
 
     for (int i = superGrammars.size() - 1; i >= 0; i--) {
-      final MCGrammarSymbol superGrammar = superGrammars.get(i).lazyLoadDelegate();
+      final MCGrammarSymbol superGrammar = superGrammars.get(i).get();
       Optional<ProdSymbol> inheritedProd = superGrammar.getProdWithInherited(ruleName);
       if (inheritedProd.isPresent()) {
         return inheritedProd;
@@ -129,9 +138,9 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
     final Map<String, ProdSymbol> ret = new LinkedHashMap<>();
 
     for (int i = superGrammars.size() - 1; i >= 0; i--) {
-      final MCGrammarSymbolSurrogate superGrammarRef = superGrammars.get(i);
+      final MCGrammarSymbol superGrammar = superGrammars.get(i).get();
 
-      for (ProdSymbol prod:superGrammarRef.lazyLoadDelegate().getProdsWithInherited().values()) {
+      for (ProdSymbol prod:superGrammar.getProdsWithInherited().values()) {
         if (ret.containsKey(prod.getName())) {
           ProdSymbol superProd = ret.get(prod.getName());
           if (MCGrammarSymbolTableHelper.getAllSuperProds(prod).contains(superProd)) {
@@ -154,9 +163,9 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
     final Collection<String> ret = Sets.newHashSet();
 
     for (int i = superGrammars.size() - 1; i >= 0; i--) {
-      final MCGrammarSymbolSurrogate superGrammarRef = superGrammars.get(i);
+      final MCGrammarSymbol superGrammarRef = superGrammars.get(i).get();
 
-      ret.addAll(superGrammarRef.lazyLoadDelegate().getTokenRulesWithInherited());
+      ret.addAll(superGrammarRef.getTokenRulesWithInherited());
     }
     forEachSplitRules(t -> ret.add(t));
     return ret;
@@ -166,9 +175,9 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
     final Collection<String> ret = Sets.newHashSet();
 
     for (int i = superGrammars.size() - 1; i >= 0; i--) {
-      final MCGrammarSymbolSurrogate superGrammarRef = superGrammars.get(i);
+      final MCGrammarSymbol superGrammarRef = superGrammars.get(i).get();
 
-      ret.addAll(superGrammarRef.lazyLoadDelegate().getKeywordRulesWithInherited());
+      ret.addAll(superGrammarRef.getKeywordRulesWithInherited());
     }
     forEachNoKeywords(t -> ret.add(t));
     return ret;
@@ -320,5 +329,18 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
     } else {
       this.replacedKeywords.put(keyword, Sets.newHashSet(additionalKeywords));
     }
+  }
+
+  // TODO: Move me elsewhere
+  public static <T> Supplier<T> memoize(Supplier<T> delegate) {
+    AtomicReference<T> value = new AtomicReference<>();
+    return () -> {
+      T val = value.get();
+      if (val == null) {
+        val = value.updateAndGet(cur -> cur == null ?
+                Objects.requireNonNull(delegate.get()) : cur);
+      }
+      return val;
+    };
   }
 }

--- a/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/MCGrammarSymbol.java
+++ b/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/MCGrammarSymbol.java
@@ -25,7 +25,7 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
 
   public static final String DEFAULT_MODE = "DEFAULT_MODE";
 
-  protected final List<Supplier<MCGrammarSymbol>> superGrammars = new ArrayList<>();
+  protected final List<Supplier<Optional<MCGrammarSymbol>>> superGrammars = new ArrayList<>();
 
   protected Map<String, Collection<String>> tokenModes = Maps.newHashMap();
 
@@ -74,8 +74,14 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
     return this.getSuperGrammarSymbols();
   }
 
+  /**
+   * Returns the list of super grammar symbols.
+   * Resolves these symbols if needed.
+   * @throws NoSuchElementException in case errors during the symbol resolution were ignored
+   * @return the list of resolved super grammar symbols
+   */
   public List<MCGrammarSymbol> getSuperGrammarSymbols() {
-    return superGrammars.stream().map(Supplier::get).collect(toList());
+    return superGrammars.stream().map(Supplier::get).map(Optional::orElseThrow).collect(toList());
   }
 
   public List<MCGrammarSymbol> getAllSuperGrammars() {
@@ -84,16 +90,18 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
     for (MCGrammarSymbol superGrammar : supGrammars) {
       superGrammar.getAllSuperGrammars().stream().filter(s -> !superSuperGrammars.contains(s)).forEach(s -> superSuperGrammars.add(s));
     }
-    superSuperGrammars.stream().filter(s -> !supGrammars.contains(s)).forEach(s->supGrammars.add(s));
+    superSuperGrammars.stream().filter(s -> !supGrammars.contains(s)).forEach(supGrammars::add);
     return copyOf(supGrammars);
   }
 
+  @Deprecated
   public void addSuperGrammar(Supplier<MCGrammarSymbol> superGrammarRef) {
-    this.superGrammars.add(Preconditions.checkNotNull(superGrammarRef));
+    Preconditions.checkNotNull(superGrammarRef);
+    this.superGrammars.add(() -> Optional.ofNullable(superGrammarRef.get()));
   }
 
-  public void addSuperGrammarSupplier(Supplier<MCGrammarSymbol> superGrammarRef) {
-    this.superGrammars.add(memoize(Preconditions.checkNotNull(superGrammarRef)));
+  public void addSuperGrammarSupplier(Supplier<Optional<MCGrammarSymbol>> superGrammarRef) {
+    this.superGrammars.add(Preconditions.checkNotNull(superGrammarRef));
   }
 
   public Collection<ProdSymbol> getProds() {
@@ -124,7 +132,7 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
     final Map<String, ProdSymbol> map = new LinkedHashMap<>();
 
     for (int i = superGrammars.size() - 1; i >= 0; i--) {
-      final MCGrammarSymbol superGrammar = superGrammars.get(i).get();
+      final MCGrammarSymbol superGrammar = superGrammars.get(i).get().get();
       Optional<ProdSymbol> inheritedProd = superGrammar.getProdWithInherited(ruleName);
       if (inheritedProd.isPresent()) {
         return inheritedProd;
@@ -138,7 +146,7 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
     final Map<String, ProdSymbol> ret = new LinkedHashMap<>();
 
     for (int i = superGrammars.size() - 1; i >= 0; i--) {
-      final MCGrammarSymbol superGrammar = superGrammars.get(i).get();
+      final MCGrammarSymbol superGrammar = superGrammars.get(i).get().get();
 
       for (ProdSymbol prod:superGrammar.getProdsWithInherited().values()) {
         if (ret.containsKey(prod.getName())) {
@@ -163,7 +171,7 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
     final Collection<String> ret = Sets.newHashSet();
 
     for (int i = superGrammars.size() - 1; i >= 0; i--) {
-      final MCGrammarSymbol superGrammarRef = superGrammars.get(i).get();
+      final MCGrammarSymbol superGrammarRef = superGrammars.get(i).get().get();
 
       ret.addAll(superGrammarRef.getTokenRulesWithInherited());
     }
@@ -175,7 +183,7 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
     final Collection<String> ret = Sets.newHashSet();
 
     for (int i = superGrammars.size() - 1; i >= 0; i--) {
-      final MCGrammarSymbol superGrammarRef = superGrammars.get(i).get();
+      final MCGrammarSymbol superGrammarRef = superGrammars.get(i).get().get();
 
       ret.addAll(superGrammarRef.getKeywordRulesWithInherited());
     }
@@ -329,18 +337,5 @@ public class MCGrammarSymbol extends MCGrammarSymbolTOP {
     } else {
       this.replacedKeywords.put(keyword, Sets.newHashSet(additionalKeywords));
     }
-  }
-
-  // TODO: Move me elsewhere
-  public static <T> Supplier<T> memoize(Supplier<T> delegate) {
-    AtomicReference<T> value = new AtomicReference<>();
-    return () -> {
-      T val = value.get();
-      if (val == null) {
-        val = value.updateAndGet(cur -> cur == null ?
-                Objects.requireNonNull(delegate.get()) : cur);
-      }
-      return val;
-    };
   }
 }

--- a/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/MCGrammarSymbolBuilder.java
+++ b/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/MCGrammarSymbolBuilder.java
@@ -5,19 +5,20 @@ import com.google.common.base.Preconditions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 public class MCGrammarSymbolBuilder extends MCGrammarSymbolBuilderTOP {
 
-  protected final List<Supplier<MCGrammarSymbol>> superGrammars = new ArrayList<>();
+  protected final List<Supplier<Optional<MCGrammarSymbol>>> superGrammars = new ArrayList<>();
 
-  public void addSuperGrammarSupplier(Supplier<MCGrammarSymbol> superGrammarRef) {
+  public void addSuperGrammarSupplier(Supplier<Optional<MCGrammarSymbol>> superGrammarRef) {
     this.superGrammars.add(Preconditions.checkNotNull(superGrammarRef));
   }
 
   public MCGrammarSymbol build(){
     MCGrammarSymbol symbol = super.build();
-    superGrammars.forEach(symbol::addSuperGrammar);
+    superGrammars.forEach(symbol::addSuperGrammarSupplier);
     return symbol;
   }
 

--- a/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/MCGrammarSymbolBuilder.java
+++ b/monticore-grammar/src/main/java/de/monticore/grammar/grammar/_symboltable/MCGrammarSymbolBuilder.java
@@ -5,12 +5,13 @@ import com.google.common.base.Preconditions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 public class MCGrammarSymbolBuilder extends MCGrammarSymbolBuilderTOP {
 
-  protected final List<MCGrammarSymbolSurrogate> superGrammars = new ArrayList<>();
+  protected final List<Supplier<MCGrammarSymbol>> superGrammars = new ArrayList<>();
 
-  public void addSuperGrammar(MCGrammarSymbolSurrogate superGrammarRef) {
+  public void addSuperGrammarSupplier(Supplier<MCGrammarSymbol> superGrammarRef) {
     this.superGrammars.add(Preconditions.checkNotNull(superGrammarRef));
   }
 

--- a/monticore-grammar/src/test/java/de/monticore/SymbolImportTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/SymbolImportTest.java
@@ -73,16 +73,13 @@ public class SymbolImportTest {
     Grammar_WithConceptsMill.scopesGenitorDelegator().createFromAST(grammarOpt.get());
     MCGrammarSymbol symbol = grammarOpt.get().getSymbol();
 
-    for (MCGrammarSymbolSurrogate surrogate : symbol.getSuperGrammars()) {
-      assertTrue(surrogate.checkLazyLoadDelegate(), "Unable to lazy load delegate " + surrogate.getName() + " of " + surrogate.getEnclosingScope());
-    }
 
     String allSuperGrammars = symbol.getSuperGrammars().stream().map(MCGrammarSymbol::getFullName).collect(Collectors.joining(", "));
-    String allSuperGrammarsLazy = symbol.getSuperGrammars().stream().map(MCGrammarSymbolSurrogate::lazyLoadDelegate).map(MCGrammarSymbol::getFullName).collect(Collectors.joining(", "));
+    String allSuperGrammarsLazy = symbol.getSuperGrammars().stream().map(MCGrammarSymbol::getFullName).collect(Collectors.joining(", "));
 
     // check if the surrogate is returning the correct symbol
-    assertTrue(symbol.getSuperGrammars().stream().anyMatch(x -> x.lazyLoadDelegate().getFullName().equals("de.monticore.grammar.SamePackage")), "SamePackage import failed: " + allSuperGrammars);
-    assertTrue(symbol.getSuperGrammars().stream().anyMatch(x -> x.lazyLoadDelegate().getFullName().equals("de.monticore.grammar.pack.DifferentPackage")), "DifferentPackage import failed: " + allSuperGrammars);
+    assertTrue(symbol.getSuperGrammars().stream().anyMatch(x -> x.getFullName().equals("de.monticore.grammar.SamePackage")), "SamePackage import failed: " + allSuperGrammars);
+    assertTrue(symbol.getSuperGrammars().stream().anyMatch(x -> x.getFullName().equals("de.monticore.grammar.pack.DifferentPackage")), "DifferentPackage import failed: " + allSuperGrammars);
 
     // check if the surrogate is returning the correct fullname
     assertTrue(symbol.getSuperGrammars().stream().anyMatch(x -> x.getFullName().equals("de.monticore.grammar.SamePackage")), "SamePackage lazy import failed: " + allSuperGrammarsLazy);

--- a/monticore-grammar/src/test/java/de/monticore/grammar/symboltable/MontiCoreGrammarSymbolTableCreatorTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/grammar/symboltable/MontiCoreGrammarSymbolTableCreatorTest.java
@@ -211,10 +211,10 @@ public class MontiCoreGrammarSymbolTableCreatorTest {
     assertTrue(grammar.getStartProd().isPresent());
     
     assertEquals(1, grammar.getSuperGrammars().size());
-    MCGrammarSymbolSurrogate superGrammarRef = grammar.getSuperGrammars().get(0);
+    MCGrammarSymbol superGrammarRef = grammar.getSuperGrammars().get(0);
     assertEquals("Statechart", superGrammarRef.getName());
     assertEquals("de.monticore.Statechart", superGrammarRef.getFullName());
-    testGrammarSymbolOfStatechart(superGrammarRef.lazyLoadDelegate());
+    testGrammarSymbolOfStatechart(superGrammarRef);
     
     ProdSymbol firstProd = grammar.getProd("First").orElse(null);
     assertNotNull(firstProd);
@@ -259,8 +259,8 @@ public class MontiCoreGrammarSymbolTableCreatorTest {
     assertEquals(5, countInterfaceAndAbstractProds(grammar));
     
     assertEquals(1, grammar.getSuperGrammars().size());
-    final MCGrammarSymbolSurrogate superGrammarRef = grammar.getSuperGrammars().get(0);
-    final String superGrammarFullName = superGrammarRef.lazyLoadDelegate().getFullName();
+    final MCGrammarSymbol superGrammarRef = grammar.getSuperGrammars().get(0);
+    final String superGrammarFullName = superGrammarRef.getFullName();
     assertEquals("de.monticore.common.TestLiterals", superGrammarFullName);
     
     ProdSymbol prod = grammar.getProdWithInherited("StringLiteral").orElse(null);

--- a/monticore-runtime/src/main/java/de/monticore/symboltable/ISymbolSupplier.java
+++ b/monticore-runtime/src/main/java/de/monticore/symboltable/ISymbolSupplier.java
@@ -12,15 +12,12 @@ import java.util.function.Supplier;
  * (which did not support composition, a TypeSurrogate
  * did not actually surrogate a CDTypeSurrogate, with CDTypeSym extends TypeSym.)
  * Errors during resolving are logged and an empty optional is returned.
+ * Use {@link #memoize(ISymbolSupplier)} to only resolve for a symbol once.
  *
  * @param <T> the symbol type
  */
-public interface ISymbolSupplier<T> extends Supplier<Optional<T>> {
+public interface ISymbolSupplier<T extends ISymbol> extends Supplier<Optional<T>> {
 
-
-  interface IMemoizedSymbolSupplier<T> extends ISymbolSupplier<T> {
-
-  }
 
   /**
    * Memoize a supplier: Only attempt to resolve once
@@ -29,12 +26,12 @@ public interface ISymbolSupplier<T> extends Supplier<Optional<T>> {
    * @param <T>      the symbol type
    * @return a memoized supplier (that only resolved once)
    */
-  @SuppressWarnings("all")
-  public static <T> IMemoizedSymbolSupplier<T> memoize(ISymbolSupplier<T> supplier) {
+  @SuppressWarnings({"OptionalAssignedToNull", "unused"})
+  static <T extends ISymbol> ISymbolSupplier<T> memoize(ISymbolSupplier<T> supplier) {
     AtomicReference<Optional<T>> value = new AtomicReference<>();
     return () -> {
       Optional<T> val = value.get();
-      if (val == null) {
+      if (val == null) { // we explicitly check against null (unset)
         val = value.updateAndGet(cur -> cur == null ?
                 Objects.requireNonNull(supplier.get()) : cur);
       }

--- a/monticore-runtime/src/main/java/de/monticore/symboltable/ISymbolSupplier.java
+++ b/monticore-runtime/src/main/java/de/monticore/symboltable/ISymbolSupplier.java
@@ -1,0 +1,44 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.symboltable;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * Supplies a symbol on demand.
+ * This class acts as a replacement to the SymbolSurrogates
+ * (which did not support composition, a TypeSurrogate
+ * did not actually surrogate a CDTypeSurrogate, with CDTypeSym extends TypeSym.)
+ * Errors during resolving are logged and an empty optional is returned.
+ *
+ * @param <T> the symbol type
+ */
+public interface ISymbolSupplier<T> extends Supplier<Optional<T>> {
+
+
+  interface IMemoizedSymbolSupplier<T> extends ISymbolSupplier<T> {
+
+  }
+
+  /**
+   * Memoize a supplier: Only attempt to resolve once
+   *
+   * @param supplier the supplier
+   * @param <T>      the symbol type
+   * @return a memoized supplier (that only resolved once)
+   */
+  @SuppressWarnings("all")
+  public static <T> IMemoizedSymbolSupplier<T> memoize(ISymbolSupplier<T> supplier) {
+    AtomicReference<Optional<T>> value = new AtomicReference<>();
+    return () -> {
+      Optional<T> val = value.get();
+      if (val == null) {
+        val = value.updateAndGet(cur -> cur == null ?
+                Objects.requireNonNull(supplier.get()) : cur);
+      }
+      return val;
+    };
+  }
+}


### PR DESCRIPTION
* Generate SymbolSuppliers (that lazily load symbols, but do not act as surrogates)
* Replace MCGrammarSymbol#superGrammars with a handwritten implementation of these suppliers

Dependson #270 