### PR TITLE
TR-Backtracking between matches

### DIFF
--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/ConstantCode.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/ConstantCode.ftl
@@ -11,6 +11,10 @@
   protected List<Match> allMatches;
   protected boolean doReplacementExecuted = false;
   protected boolean isHostGraphDirty = true;
+
+  protected Stack<String> backtracking = new Stack<>();
+  protected Stack<String> backtrackingNegative = new Stack<>();
+
   <#-- for each object creates a _candidates, _candidates_temp nodelist and an _cand object-->
 
   // Matches

--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatching.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatching.ftl
@@ -33,8 +33,6 @@ public boolean doPatternMatching() {
     splitSearchplan(); // for OptList structures
     isBacktracking = false;
   }
-  Stack<String> backtracking = new Stack<String>();
-  Stack<String> backtrackingNegative = new Stack<String>();
   String nextNode = null;
   while(!searchPlan.isEmpty()) {
     nextNode = searchPlan.pop();
@@ -93,6 +91,9 @@ public boolean doPatternMatching() {
       searchPlan.push(nextNode);
     }
     allMatches.add(match);
+    // And remove last backtracking
+    if (!backtracking.isEmpty())
+      backtracking.pop();
   }
   return foundMatch;
 }

--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatchingList.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatchingList.ftl
@@ -149,7 +149,7 @@ public boolean doPatternMatching_${structure.getObjectName()}(boolean isParentBa
                   searchPlan.push(nextNode);
                   // put the first object of the backtracking stack
                   searchPlan.push(backtracking.pop());
-                  // TODO: TEST ME
+                  // reset the optional candidate
                   reset_${object.getObjectName()}();
                   this.opt_found_${object.getObjectName()} = false;
                 }

--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatchingList.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatchingList.ftl
@@ -55,6 +55,7 @@ public boolean doPatternMatching_${structure.getObjectName()}(boolean isParentBa
       }
     }
 
+		boolean hasFoundAtLeastOneMatch = false;
     while(foundmatch) {
       // If the parent was Backtracking don't load a new searchPlan
       if (!isBacktracking) {
@@ -283,6 +284,7 @@ public boolean doPatternMatching_${structure.getObjectName()}(boolean isParentBa
         </#list>
         ${structure.getObjectName()}_candidates.add(match);
         backtracking.clear();
+				hasFoundAtLeastOneMatch = true;
       }
     }
 
@@ -295,7 +297,7 @@ public boolean doPatternMatching_${structure.getObjectName()}(boolean isParentBa
 
     // TODO: Do something similar for optionals (but somehow do not loose them?)
 
-    if(${structure.getObjectName()}_candidates.isEmpty()) {
+    if (!hasFoundAtLeastOneMatch) {
       return false;
     }
     ${structure.getObjectName()}_cand = ${structure.getObjectName()}_candidates;

--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatchingList.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatchingList.ftl
@@ -39,7 +39,7 @@ public boolean doPatternMatching_${structure.getObjectName()}(boolean isParentBa
       ${structure.getObjectName()}_candidates.remove(${structure.getObjectName()}_candidates.size()-1);
       // Load the Objects and Their temp_candidates
       <#list mandatoryObjects as object>
-        ${object.getObjectName()}_cand = match.${object.getObjectName()}<#if hierarchyHelper.isWithinOptionalStructure(object.getObjectName())>.get()</#if>;
+        ${object.getObjectName()}_cand = match.${object.getObjectName()}<#if hierarchyHelper.isWithinOptionalStructure(object.getObjectName())>.orElse(null)</#if>;
         ${object.getObjectName()}_candidates_temp = match.${object.getObjectName()}_temp_candidates;
       </#list>
       // Get the BacktrackingStack

--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatchingList.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatchingList.ftl
@@ -55,11 +55,18 @@ public boolean doPatternMatching_${structure.getObjectName()}(boolean isParentBa
       }
     }
 
-		boolean hasFoundAtLeastOneMatch = false;
+    boolean hasFoundAtLeastOneMatch = false;
     while(foundmatch) {
       // If the parent was Backtracking don't load a new searchPlan
       if (!isBacktracking) {
         searchPlan = (Stack<String>) searchPlan_${structure.getObjectName()}.clone();
+        // also reset all optional "counter" of opts within this list
+				<#list allObjects as object>
+					<#if object.isOptObject()>
+					opt_found_${object.getObjectName()} = false;
+					</#if>
+				</#list>
+
       }
       while(!searchPlan.isEmpty()){
         nextNode = searchPlan.pop();
@@ -132,7 +139,7 @@ public boolean doPatternMatching_${structure.getObjectName()}(boolean isParentBa
                 if (backtracking.isEmpty()) {
                   // no match of the pattern can be found
                   foundmatch = false;
-									// Note: We should/could also reset the optional candidates here?
+                  // Note: We should/could also reset the optional candidates here?
                   break;
                 }
                 else {
@@ -142,9 +149,9 @@ public boolean doPatternMatching_${structure.getObjectName()}(boolean isParentBa
                   searchPlan.push(nextNode);
                   // put the first object of the backtracking stack
                   searchPlan.push(backtracking.pop());
-									// TODO: TEST ME
-									reset_${object.getObjectName()}();
-									this.opt_found_${object.getObjectName()} = false;
+                  // TODO: TEST ME
+                  reset_${object.getObjectName()}();
+                  this.opt_found_${object.getObjectName()} = false;
                 }
               }
 
@@ -284,7 +291,7 @@ public boolean doPatternMatching_${structure.getObjectName()}(boolean isParentBa
         </#list>
         ${structure.getObjectName()}_candidates.add(match);
         backtracking.clear();
-				hasFoundAtLeastOneMatch = true;
+        hasFoundAtLeastOneMatch = true;
       }
     }
 

--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatchingList.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatchingList.ftl
@@ -101,7 +101,7 @@ public boolean doPatternMatching_${structure.getObjectName()}(boolean isParentBa
           <#elseif object.isOptObject()>
             if(nextNode.equals("${object.getObjectName()}")) {
               // this is an optional object
-              if(doPatternMatching_${object.getObjectName()}(isBacktrackingNegative)) {
+              if(doPatternMatching_${object.getObjectName()}(isBacktracking, isBacktrackingNegative)) {
 
               if(isBacktrackingNegative){
                 isBacktracking = true;
@@ -131,6 +131,7 @@ public boolean doPatternMatching_${structure.getObjectName()}(boolean isParentBa
                 if (backtracking.isEmpty()) {
                   // no match of the pattern can be found
                   foundmatch = false;
+									// Note: We should/could also reset the optional candidates here?
                   break;
                 }
                 else {
@@ -140,6 +141,9 @@ public boolean doPatternMatching_${structure.getObjectName()}(boolean isParentBa
                   searchPlan.push(nextNode);
                   // put the first object of the backtracking stack
                   searchPlan.push(backtracking.pop());
+									// TODO: TEST ME
+									reset_${object.getObjectName()}();
+									this.opt_found_${object.getObjectName()} = false;
                 }
               }
 

--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatchingOptional.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatchingOptional.ftl
@@ -2,10 +2,10 @@
 <#-- We are only interested in optional structures here -->
 <#list hierarchyHelper.getOptionalMatchObjects(ast.getPattern().getLHSObjectsList()) as structure>
 
-protected boolean doPatternMatching_${structure.getObjectName()}(boolean isParentBacktrackingNegative) {
+protected boolean doPatternMatching_${structure.getObjectName()}(boolean isParentBacktracking, boolean isParentBacktrackingNegative) {
   // indicates whether this rule is currently backtracking
   // (this will skip all attempts to match lists or negative nodes)
-  boolean isBacktracking = false;
+  boolean isBacktracking = isParentBacktracking;
   boolean isBacktrackingNegative = isParentBacktrackingNegative;
 
   Stack<String> backtracking = new Stack<String>();
@@ -13,6 +13,7 @@ protected boolean doPatternMatching_${structure.getObjectName()}(boolean isParen
   Stack<String> searchPlan = (Stack<String>) searchPlan_${structure.getObjectName()}.clone();
 
   String nextNode = null;
+	boolean foundMatch = true;
   while(!searchPlan.isEmpty()){
     nextNode = searchPlan.pop();
     <#--creates an if statement for each object for matching the object-->
@@ -31,6 +32,17 @@ protected boolean doPatternMatching_${structure.getObjectName()}(boolean isParen
       <#if object_has_next>else</#if>
     </#list>
   }
+  // Now we wish to ensure, that we always find something with an optional at least once
+  if (!foundMatch) {
+    // no match for the optional found
+    if (this.opt_found_${structure.getObjectName()}) {
+      // and this appears to be the 2nd time we try to match this opt (and have failed)
+      // -> do not match nothing a second time
+      return false;
+    }
+		// return true, as the optional is... optional
+  }
+  opt_found_${structure.getObjectName()} = true; // do not match this empty optional again
   return true;
 }
 </#list>

--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/ResetOptionals.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/ResetOptionals.ftl
@@ -2,6 +2,9 @@
 <#-- We are only interested in optional structures here -->
 <#list hierarchyHelper.getOptionalMatchObjects(ast.getPattern().getLHSObjectsList()) as structure>
 
+// To allow optionals to always match at least once
+protected boolean opt_found_${structure.getObjectName()} = false;
+
 protected void reset_${structure.getObjectName()}() {
   // TODO: correct? -> not for lists?
 <#list ast.getAllInnerNonOptionalNames(ast.getPattern().getLHSObjectsList(), structure) as elem>

--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/dopatternmatching/HandleListObject.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/dopatternmatching/HandleListObject.ftl
@@ -24,7 +24,7 @@ if (nextNode.equals("${listObject.getObjectName()}_$List")) {
           return false;
         }
       </#if>
-		  foundMatch = false;
+      foundMatch = false;
       break;
     } else {
       // start backtracking

--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/dopatternmatching/HandleListObject.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/dopatternmatching/HandleListObject.ftl
@@ -23,9 +23,8 @@ if (nextNode.equals("${listObject.getObjectName()}_$List")) {
           //Can not find a new Match, signal the parent to backtrack
           return false;
         }
-      <#else>
-        foundMatch = false;
       </#if>
+		  foundMatch = false;
       break;
     } else {
       // start backtracking

--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/dopatternmatching/HandleNormalObject.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/dopatternmatching/HandleNormalObject.ftl
@@ -24,9 +24,8 @@ if (nextNode.equals("${normalObject.getObjectName()}")) {
     // if no object ist found, test if backtracking stack is empty
     if(backtracking.isEmpty()) {
       // no match of the pattern can be found
-    <#if !isOptional>
       foundMatch = false;
-    <#elseif parentObject?has_content>
+    <#if isOptional && parentObject?has_content>
       reset_${parentObject.getObjectName()}();
     </#if>
     break;

--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/dopatternmatching/HandleNotObject.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/dopatternmatching/HandleNotObject.ftl
@@ -15,9 +15,7 @@ if (nextNode.equals("${notObject.getObjectName()}")) {
       // if no object ist found, test if backtracking stack is empty
       if (backtrackingNegative.isEmpty()) {
         // no match of negative elements can be found go on with lists
-        <#if !isOptional>
         foundMatch = true;
-        </#if>
         isBacktrackingNegative = false;
         backtracking.push(nextNode);
         while (!searchPlan.isEmpty() && !searchPlan.peek().endsWith("_$List")) {

--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/dopatternmatching/HandleOptObject.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/dopatternmatching/HandleOptObject.ftl
@@ -42,9 +42,9 @@ if (nextNode.equals("${optObject.getObjectName()}")) {
       searchPlan.push(nextNode);
       // put the first object of the backtracking stack
       searchPlan.push(backtracking.pop());
-			// TODO: TEST ME
-			reset_${optObject.getObjectName()}();
-			this.opt_found_${optObject.getObjectName()} = false;
+      // TODO: TEST ME
+      reset_${optObject.getObjectName()}();
+      this.opt_found_${optObject.getObjectName()} = false;
     }
   }
 }

--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/dopatternmatching/HandleOptObject.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/dopatternmatching/HandleOptObject.ftl
@@ -42,7 +42,7 @@ if (nextNode.equals("${optObject.getObjectName()}")) {
       searchPlan.push(nextNode);
       // put the first object of the backtracking stack
       searchPlan.push(backtracking.pop());
-      // TODO: TEST ME
+      // reset the optional candidate
       reset_${optObject.getObjectName()}();
       this.opt_found_${optObject.getObjectName()} = false;
     }

--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/dopatternmatching/HandleOptObject.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/dopatternmatching/HandleOptObject.ftl
@@ -4,7 +4,7 @@ ${signature("isOptional", "parentObject")}
 <#assign optObject = ast>
 if (nextNode.equals("${optObject.getObjectName()}")) {
   // this is an optional object
-  if (doPatternMatching_${optObject.getObjectName()}(isBacktrackingNegative)) {
+  if (doPatternMatching_${optObject.getObjectName()}(isBacktracking, isBacktrackingNegative)) {
     // Experimental
     if (isBacktrackingNegative) {
       isBacktracking = true;
@@ -30,9 +30,8 @@ if (nextNode.equals("${optObject.getObjectName()}")) {
     // if no object is found, test if backtracking stack is empty
     if (backtracking.isEmpty()) {
       // no match of the pattern can be found
-      <#if !isOptional>
       foundMatch = false;
-      <#elseif parentObject?has_content>
+      <#if isOptional && parentObject?has_content>
       reset_${parentObject.getObjectName()}();
       </#if>
       break;
@@ -43,6 +42,9 @@ if (nextNode.equals("${optObject.getObjectName()}")) {
       searchPlan.push(nextNode);
       // put the first object of the backtracking stack
       searchPlan.push(backtracking.pop());
+			// TODO: TEST ME
+			reset_${optObject.getObjectName()}();
+			this.opt_found_${optObject.getObjectName()} = false;
     }
   }
 }

--- a/monticore-test/montitrans/test-odrules/src/main/models/automaton/AutomatonSubstateList.aut
+++ b/monticore-test/montitrans/test-odrules/src/main/models/automaton/AutomatonSubstateList.aut
@@ -1,12 +1,12 @@
 /* (c) https://github.com/MontiCore/monticore */
 automaton AutomatonSubstateList {
-	state m {}
+    state m {}
     state a {
         state c;
     }
         
     state b {
-		state d;
+        state d;
     }
     
     state s {


### PR DESCRIPTION
* Fix Backtracking between matches (continued do-Patternmatching)
* Fix continued optional matching: Match them once instead of an infinite amount of times
* Fix list greedy matching: Continued matching now returns the maximum list (instead of matching the cartesian product of all lists)

Tests are the testAmount... ones [here](https://git.rwth-aachen.de/monticore/montitrans/montitransruntime/-/blob/main/example/example-dsl/src/intTest/java/unifiedtest/SCLiteTest.java#L91)