### PR TITLE
Implicit Symbol Adaption

### DIFF
--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/SymbolTableService.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/SymbolTableService.java
@@ -483,7 +483,7 @@ public class SymbolTableService extends AbstractService<SymbolTableService> {
   public String getSymbolSimpleName(ASTCDType clazz) {
     // if in grammar other symbol Name is defined e.g. 'symbol (MCType) MCQualifiedType implements MCObjectType = MCQualifiedName;'
     // this will evaluate to MCTypeSymbol
-    if (!hasSymbolStereotype(clazz.getModifier())) {
+    if (hasSymbolStereotype(clazz.getModifier()) || hasInheritedSymbolStereotype(clazz.getModifier())) {
       Optional<String> symbolTypeValue = getSymbolTypeValue(clazz.getModifier());
       if (symbolTypeValue.isPresent()) {
         return getSimpleName(symbolTypeValue.get());
@@ -499,7 +499,7 @@ public class SymbolTableService extends AbstractService<SymbolTableService> {
 
   public String getSymbolFullName(ASTCDType clazz, DiagramSymbol cdDefinitionSymbol) {
     //if in grammar other symbol Name is defined e.g. 'symbol (MCType) MCQualifiedType implements MCObjectType = MCQualifiedName;'
-    if (!hasSymbolStereotype(clazz.getModifier())) {
+    if (hasSymbolStereotype(clazz.getModifier()) || hasInheritedSymbolStereotype(clazz.getModifier())) {
       Optional<String> symbolTypeValue = getSymbolTypeValue(clazz.getModifier());
       if (symbolTypeValue.isPresent()) {
         return symbolTypeValue.get();

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/serialization/ScopeDeSerDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/serialization/ScopeDeSerDecorator.java
@@ -20,6 +20,7 @@ import de.monticore.generating.templateengine.StringHookPoint;
 import de.monticore.generating.templateengine.TemplateHookPoint;
 import de.monticore.io.paths.MCPath;
 import de.monticore.symbols.basicsymbols._symboltable.DiagramSymbol;
+import de.monticore.symboltable.serialization.ISymbolDeSer;
 import de.monticore.types.mcbasictypes._ast.ASTMCQualifiedType;
 import de.se_rwth.commons.StringTransformations;
 
@@ -45,6 +46,8 @@ public class ScopeDeSerDecorator extends AbstractDecorator {
   public static final String DESERIALIZE_IS_TEMPL = "_symboltable.serialization.scopeDeSer.DeserializeIScope";
 
   public static final String DESERIALIZE_SYMBOLS_TEMPL = "_symboltable.serialization.scopeDeSer.DeserializeSymbols";
+
+  public static final String GET_DESER = "_symboltable.serialization.scopeDeSer.GetDeser";
 
   public static final String SERIALIZES2J_TEMPL = "_symboltable.serialization.scopeDeSer.SerializeS2J4ScopeDeSer";
 
@@ -134,6 +137,8 @@ public class ScopeDeSerDecorator extends AbstractDecorator {
             scopeRuleAttrList))
         .addCDMember(
             createDeserializeSymbolsMethods(scopeVarParam, scopeJsonParam, symbolMap, millName, scopeDeSerName, scopeInterfaceName))
+        .addCDMember(
+            createGetDeserMethods(millName, scopeDeSerName))
         .addAllCDMembers(createDeserializeAttrMethods(scopeRuleAttrList, enclosingScopeParam, scopeJsonParam))
         .addAllCDMembers(createDeserializeAddonsMethods(scopeVarParam, scopeJsonParam))
         .build();
@@ -235,6 +240,22 @@ public class ScopeDeSerDecorator extends AbstractDecorator {
     String errorCode = symbolTableService.getGeneratedErrorCode("deserializeSymbols"+millName);
     this.replaceTemplate(EMPTY_BODY, method, new TemplateHookPoint(
         DESERIALIZE_SYMBOLS_TEMPL, symbolMap, millName, errorCode, scopeDeSerName, scopeInterfaceName));
+    return method;
+  }
+
+  protected ASTCDMethod createGetDeserMethods(String millName,
+                                              String scopeDeSerName) {
+    // Method that tries to find a deSer (walks up the symbol hierarchy as a fallback)
+    ASTCDParameter kindParam = getCDParameterFacade()
+            .createParameter(getMCTypeFacade().createStringType(), "kind");
+    ASTCDParameter jsonParam = getCDParameterFacade()
+            .createParameter(getMCTypeFacade().createOptionalTypeOf(JSON_OBJECT), "symbolHierarchiesObjectOpt");
+    ASTCDMethod method = getCDMethodFacade()
+            .createMethod(PROTECTED.build(), getMCTypeFacade().createQualifiedType(ISymbolDeSer.class),
+                          "getDeser", kindParam, jsonParam);
+    String errorCode = symbolTableService.getGeneratedErrorCode("getDeser"+millName);
+    this.replaceTemplate(EMPTY_BODY, method, new TemplateHookPoint(
+            GET_DESER, millName, errorCode, scopeDeSerName));
     return method;
   }
 

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/serialization/ScopeDeSerDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/serialization/ScopeDeSerDecorator.java
@@ -140,7 +140,7 @@ public class ScopeDeSerDecorator extends AbstractDecorator {
         .addCDMember(
             createGetDeserMethod(millName, scopeDeSerName))
         .addCDMember(
-            getCDAttributeFacade().createAttribute(PROTECTED.build(), getMCTypeFacade().createOptionalTypeOf(JSON_OBJECT), "symbolHierarchiesObjectOpt"))
+            getCDAttributeFacade().createAttribute(PROTECTED.build(), getMCTypeFacade().createOptionalTypeOf(JSON_OBJECT), "symbolHierarchiesJsonObjectOpt"))
         .addAllCDMembers(createDeserializeAttrMethods(scopeRuleAttrList, enclosingScopeParam, scopeJsonParam))
         .addAllCDMembers(createDeserializeAddonsMethods(scopeVarParam, scopeJsonParam))
         .build();

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/serialization/ScopeDeSerDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/serialization/ScopeDeSerDecorator.java
@@ -138,7 +138,9 @@ public class ScopeDeSerDecorator extends AbstractDecorator {
         .addCDMember(
             createDeserializeSymbolsMethods(scopeVarParam, scopeJsonParam, symbolMap, millName, scopeDeSerName, scopeInterfaceName))
         .addCDMember(
-            createGetDeserMethods(millName, scopeDeSerName))
+            createGetDeserMethod(millName, scopeDeSerName))
+        .addCDMember(
+            getCDAttributeFacade().createAttribute(PROTECTED.build(), getMCTypeFacade().createOptionalTypeOf(JSON_OBJECT), "symbolHierarchiesObjectOpt"))
         .addAllCDMembers(createDeserializeAttrMethods(scopeRuleAttrList, enclosingScopeParam, scopeJsonParam))
         .addAllCDMembers(createDeserializeAddonsMethods(scopeVarParam, scopeJsonParam))
         .build();
@@ -243,16 +245,14 @@ public class ScopeDeSerDecorator extends AbstractDecorator {
     return method;
   }
 
-  protected ASTCDMethod createGetDeserMethods(String millName,
-                                              String scopeDeSerName) {
+  protected ASTCDMethod createGetDeserMethod(String millName,
+                                             String scopeDeSerName) {
     // Method that tries to find a deSer (walks up the symbol hierarchy as a fallback)
     ASTCDParameter kindParam = getCDParameterFacade()
             .createParameter(getMCTypeFacade().createStringType(), "kind");
-    ASTCDParameter jsonParam = getCDParameterFacade()
-            .createParameter(getMCTypeFacade().createOptionalTypeOf(JSON_OBJECT), "symbolHierarchiesObjectOpt");
     ASTCDMethod method = getCDMethodFacade()
             .createMethod(PROTECTED.build(), getMCTypeFacade().createQualifiedType(ISymbolDeSer.class),
-                          "getDeser", kindParam, jsonParam);
+                          "getDeser", kindParam);
     String errorCode = symbolTableService.getGeneratedErrorCode("getDeser"+millName);
     this.replaceTemplate(EMPTY_BODY, method, new TemplateHookPoint(
             GET_DESER, millName, errorCode, scopeDeSerName));

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/serialization/Symbols2JsonDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/serialization/Symbols2JsonDecorator.java
@@ -29,6 +29,7 @@ import de.se_rwth.commons.StringTransformations;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static de.monticore.cd.codegen.CD2JavaTemplates.EMPTY_BODY;
 import static de.monticore.cd.codegen.CD2JavaTemplates.VALUE;
@@ -112,6 +113,7 @@ public class Symbols2JsonDecorator extends AbstractDecorator {
             .addAllCDMembers(createConstructors(millName, traverserFullName, symbols2JsonName, superGrammars))
             .addCDMember(createInitMethod(scopeInterfaceFullName, symbolDefiningProds))
             .addCDMember(createGetSerializedStringMethod())
+            .addCDMember(createWriteSymbolHierarchies())
             .addAllCDMembers(createLoadMethods(artifactScopeInterfaceFullName))
             .addCDMember(createStoreMethod(artifactScopeInterfaceFullName))
             .addAllCDMembers(createScopeVisitorMethods(scopeInterfaceFullName, symbols2JsonName))
@@ -215,6 +217,22 @@ public class Symbols2JsonDecorator extends AbstractDecorator {
     return method;
   }
 
+  protected ASTCDMethod createWriteSymbolHierarchies() {
+    ASTCDMethod method = getCDMethodFacade().createMethod(PUBLIC.build(), "writeSymbolHierarchies");
+    // Map SymbolClassName -> SuperSymbolClassName
+    Map<String, String> symbolToSuperSymbolsMap = symbolTableService.getInheritedSymbolPropertyTypes(
+                    symbolTableService.getSymbolDefiningSuperProds())
+            .entrySet().stream().collect(
+                    Collectors.toMap(
+                            e -> symbolTableService.getSymbolFullName(e.getKey()),
+                            Map.Entry::getValue));
+
+    this.replaceTemplate(EMPTY_BODY, method, new TemplateHookPoint(TEMPLATE_PATH
+            + "symbols2Json.WriteSymbolHierarchies",
+            symbolToSuperSymbolsMap));
+    return method;
+  }
+
   protected List<ASTCDMethod> createScopeVisitorMethods(String scopeInterfaceName, String symbols2Json) {
     List<ASTCDMethod> visitorMethods = new ArrayList<>();
 
@@ -225,7 +243,7 @@ public class Symbols2JsonDecorator extends AbstractDecorator {
 
     ASTCDMethod endVisitMethod = visitorService.getVisitorMethod(END_VISIT, getMCTypeFacade().createQualifiedType(scopeInterfaceName));
     this.replaceTemplate(EMPTY_BODY, endVisitMethod, new TemplateHookPoint(TEMPLATE_PATH
-            + "symbols2Json.EndVisit4Scope", I_SCOPE, symbols2Json));
+            + "symbols2Json.EndVisit4Scope", I_SCOPE, symbols2Json, false));
     visitorMethods.add(endVisitMethod);
 
     return visitorMethods;
@@ -241,7 +259,7 @@ public class Symbols2JsonDecorator extends AbstractDecorator {
     ASTCDMethod endVisitMethod = visitorService
             .getVisitorMethod(END_VISIT, getMCTypeFacade().createQualifiedType(artifactScopeInterfaceName));
     this.replaceTemplate(EMPTY_BODY, endVisitMethod, new TemplateHookPoint(TEMPLATE_PATH
-            + "symbols2Json.EndVisit4Scope", I_ARTIFACT_SCOPE_TYPE, symbols2Json));
+            + "symbols2Json.EndVisit4Scope", I_ARTIFACT_SCOPE_TYPE, symbols2Json, true));
     visitorMethods.add(endVisitMethod);
 
     return visitorMethods;

--- a/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/serialization/Symbols2JsonDecorator.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/cd2java/_symboltable/serialization/Symbols2JsonDecorator.java
@@ -113,7 +113,7 @@ public class Symbols2JsonDecorator extends AbstractDecorator {
             .addAllCDMembers(createConstructors(millName, traverserFullName, symbols2JsonName, superGrammars))
             .addCDMember(createInitMethod(scopeInterfaceFullName, symbolDefiningProds))
             .addCDMember(createGetSerializedStringMethod())
-            .addCDMember(createWriteSymbolHierarchies())
+            .addCDMember(createWriteSymbolHierarchies(symbolDefiningProds))
             .addAllCDMembers(createLoadMethods(artifactScopeInterfaceFullName))
             .addCDMember(createStoreMethod(artifactScopeInterfaceFullName))
             .addAllCDMembers(createScopeVisitorMethods(scopeInterfaceFullName, symbols2JsonName))
@@ -217,11 +217,13 @@ public class Symbols2JsonDecorator extends AbstractDecorator {
     return method;
   }
 
-  protected ASTCDMethod createWriteSymbolHierarchies() {
+  protected ASTCDMethod createWriteSymbolHierarchies(List<ASTCDType> symbolDefiningProds) {
     ASTCDMethod method = getCDMethodFacade().createMethod(PUBLIC.build(), "writeSymbolHierarchies");
+    // Collect all symbols of both this grammar and all its super grammars
+    List<ASTCDType> allSymbolDefiningProdsTransitive = new ArrayList<>(symbolDefiningProds);
+    allSymbolDefiningProdsTransitive.addAll(symbolTableService.getSymbolDefiningSuperProds());
     // Map SymbolClassName -> SuperSymbolClassName
-    Map<String, String> symbolToSuperSymbolsMap = symbolTableService.getInheritedSymbolPropertyTypes(
-                    symbolTableService.getSymbolDefiningSuperProds())
+    Map<String, String> symbolToSuperSymbolsMap = symbolTableService.getInheritedSymbolPropertyTypes(allSymbolDefiningProdsTransitive)
             .entrySet().stream().collect(
                     Collectors.toMap(
                             e -> symbolTableService.getSymbolFullName(e.getKey()),

--- a/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/transl/SymbolAndScopeTranslation.java
+++ b/monticore-generator/src/main/java/de/monticore/codegen/mc2cd/transl/SymbolAndScopeTranslation.java
@@ -55,7 +55,8 @@ public class SymbolAndScopeTranslation implements
     for (ASTSymbolDefinition symbolDefinition : grammarProd.getSymbolDefinitionList()) {
       if (symbolDefinition.isGenSymbol()) {
           TransformationHelper.addStereoType(cdType,
-              MC2CDStereotypes.SYMBOL.toString());
+              MC2CDStereotypes.SYMBOL.toString(),
+              getSymbolName(grammarProd.getSymbol()));
       }
     }
   }

--- a/monticore-generator/src/main/resources/_symboltable/serialization/scopeDeSer/DeserializeArtifactScope.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/serialization/scopeDeSer/DeserializeArtifactScope.ftl
@@ -21,10 +21,10 @@ ${tc.signature("symTabMill", "artifactScope", "scopeRuleAttrList")}
   </#if>
 </#list>
 
-  this.symbolHierarchiesObjectOpt = scopeJson.getObjectMemberOpt(de.monticore.symboltable.serialization.JsonDeSers.SYMBOL_HIERARCHY);
+  this.symbolHierarchiesJsonObjectOpt = scopeJson.getObjectMemberOpt(de.monticore.symboltable.serialization.JsonDeSers.SYMBOL_HIERARCHY);
 
   deserializeAddons(scope,scopeJson);
   deserializeSymbols(scope, scopeJson);
 
-  this.symbolHierarchiesObjectOpt = Optional.empty();
+  this.symbolHierarchiesJsonObjectOpt = Optional.empty();
   return scope;

--- a/monticore-generator/src/main/resources/_symboltable/serialization/scopeDeSer/DeserializeArtifactScope.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/serialization/scopeDeSer/DeserializeArtifactScope.ftl
@@ -21,6 +21,10 @@ ${tc.signature("symTabMill", "artifactScope", "scopeRuleAttrList")}
   </#if>
 </#list>
 
+  this.symbolHierarchiesObjectOpt = scopeJson.getObjectMemberOpt(de.monticore.symboltable.serialization.JsonDeSers.SYMBOL_HIERARCHY);
+
   deserializeAddons(scope,scopeJson);
   deserializeSymbols(scope, scopeJson);
+
+  this.symbolHierarchiesObjectOpt = Optional.empty();
   return scope;

--- a/monticore-generator/src/main/resources/_symboltable/serialization/scopeDeSer/DeserializeSymbols.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/serialization/scopeDeSer/DeserializeSymbols.ftl
@@ -10,8 +10,7 @@ ${tc.signature("symbolMap", "mill", "errorCode", "scopeDeserName", "scopeInterfa
       continue;
     }
 
-    de.monticore.symboltable.serialization.ISymbolDeSer deSer = getDeser(kind.get(),
-      scopeJson.getObjectMemberOpt(de.monticore.symboltable.serialization.JsonDeSers.SYMBOL_HIERARCHY));
+    de.monticore.symboltable.serialization.ISymbolDeSer deSer = this.getDeser(kind.get());
 
     if (null == deSer) {
       Log.debug(

--- a/monticore-generator/src/main/resources/_symboltable/serialization/scopeDeSer/DeserializeSymbols.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/serialization/scopeDeSer/DeserializeSymbols.ftl
@@ -10,7 +10,8 @@ ${tc.signature("symbolMap", "mill", "errorCode", "scopeDeserName", "scopeInterfa
       continue;
     }
 
-    de.monticore.symboltable.serialization.ISymbolDeSer deSer = ${mill}.globalScope().getSymbolDeSer(kind.get());
+    de.monticore.symboltable.serialization.ISymbolDeSer deSer = getDeser(kind.get(),
+      scopeJson.getObjectMemberOpt(de.monticore.symboltable.serialization.JsonDeSers.SYMBOL_HIERARCHY));
 
     if (null == deSer) {
       Log.debug(

--- a/monticore-generator/src/main/resources/_symboltable/serialization/scopeDeSer/GetDeser.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/serialization/scopeDeSer/GetDeser.ftl
@@ -3,17 +3,17 @@ ${tc.signature("mill", "debugCode", "scopeDeserName")}
 de.monticore.symboltable.serialization.ISymbolDeSer deSer = ${mill}.globalScope().getSymbolDeSer(kind);
 
 String previousKind;
-while (deSer == null && symbolHierarchiesObjectOpt.isPresent()) {
+while (deSer == null && this.symbolHierarchiesObjectOpt.isPresent()) {
   // Walk the symbol-hierarchy up until we can find a registered deSer
   previousKind = kind;
-  if (!symbolHierarchiesObjectOpt.get().hasStringMember(kind)) {
+  if (!this.symbolHierarchiesObjectOpt.get().hasStringMember(kind)) {
     Log.debug(
       "0xA1236x${debugCode} The artifact scope does not define a super symbol for symbol kind `" + kind + "`.",
       ${scopeDeserName}.class.getName()
     );
     break;
   }
-  kind = symbolHierarchiesObjectOpt.get().getStringMember(kind);
+  kind = this.symbolHierarchiesObjectOpt.get().getStringMember(kind);
   Log.debug(
     "0xA1235x${debugCode} No DeSer found to deserialize symbol of kind `" + previousKind
     + "`. Using the super symbol kind `" + kind + "` instead.",

--- a/monticore-generator/src/main/resources/_symboltable/serialization/scopeDeSer/GetDeser.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/serialization/scopeDeSer/GetDeser.ftl
@@ -3,25 +3,25 @@ ${tc.signature("mill", "debugCode", "scopeDeserName")}
 de.monticore.symboltable.serialization.ISymbolDeSer deSer = ${mill}.globalScope().getSymbolDeSer(kind);
 
 String previousKind;
-while (deSer == null && this.symbolHierarchiesObjectOpt.isPresent()) {
+while (deSer == null && this.symbolHierarchiesJsonObjectOpt.isPresent()) {
   // Walk the symbol-hierarchy up until we can find a registered deSer
   previousKind = kind;
-  if (!this.symbolHierarchiesObjectOpt.get().hasStringMember(kind)) {
+  if (!this.symbolHierarchiesJsonObjectOpt.get().hasStringMember(kind)) {
     Log.debug(
       "0xA1236x${debugCode} The artifact scope does not define a super symbol for symbol kind `" + kind + "`.",
       ${scopeDeserName}.class.getName()
     );
     break;
   }
-  kind = this.symbolHierarchiesObjectOpt.get().getStringMember(kind);
+  kind = this.symbolHierarchiesJsonObjectOpt.get().getStringMember(kind);
   Log.debug(
     "0xA1235x${debugCode} No DeSer found to deserialize symbol of kind `" + previousKind
     + "`. Using the super symbol kind `" + kind + "` instead.",
     ${scopeDeserName}.class.getName()
   );
-  // an in case we find a deser for that type -> exit the loop
+  // in case we find a deser for that type -> exit the loop
   deSer = ${mill}.globalScope().getSymbolDeSer(kind);
-  // otherwise continue to walk up
+  // otherwise: continue to walk up
 }
 
 return deSer;

--- a/monticore-generator/src/main/resources/_symboltable/serialization/scopeDeSer/GetDeser.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/serialization/scopeDeSer/GetDeser.ftl
@@ -1,0 +1,27 @@
+<#-- (c) https://github.com/MontiCore/monticore -->
+${tc.signature("mill", "debugCode", "scopeDeserName")}
+de.monticore.symboltable.serialization.ISymbolDeSer deSer = ${mill}.globalScope().getSymbolDeSer(kind);
+
+String previousKind;
+while (deSer == null && symbolHierarchiesObjectOpt.isPresent()) {
+  // Walk the symbol-hierarchy up until we can find a registered deSer
+  previousKind = kind;
+  if (!symbolHierarchiesObjectOpt.get().hasStringMember(kind)) {
+    Log.debug(
+      "0xA1236x${debugCode} The artifact scope does not define a super symbol for symbol kind `" + kind + "`.",
+      ${scopeDeserName}.class.getName()
+    );
+    break;
+  }
+  kind = symbolHierarchiesObjectOpt.get().getStringMember(kind);
+  Log.debug(
+    "0xA1235x${debugCode} No DeSer found to deserialize symbol of kind `" + previousKind
+    + "`. Using the super symbol kind `" + kind + "` instead.",
+    ${scopeDeserName}.class.getName()
+  );
+  // an in case we find a deser for that type -> exit the loop
+  deSer = ${mill}.globalScope().getSymbolDeSer(kind);
+  // otherwise continue to walk up
+}
+
+return deSer;

--- a/monticore-generator/src/main/resources/_symboltable/serialization/symbols2Json/EndVisit4Scope.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/serialization/symbols2Json/EndVisit4Scope.ftl
@@ -1,6 +1,12 @@
 <#-- (c) https://github.com/MontiCore/monticore -->
-${tc.signature("rteScope", "symbols2Json")}
+${tc.signature("rteScope", "symbols2Json", "isArtifactScope")}
 
 getJsonPrinter().endArray();
 scopeDeSer.serializeAddons(node, getRealThis());
+<#if isArtifactScope>
+	// store symbol hierarchy to fallback in case of unknown symbols
+	getJsonPrinter().beginObject(de.monticore.symboltable.serialization.JsonDeSers.SYMBOL_HIERARCHY);
+	this.writeSymbolHierarchies();
+	getJsonPrinter().endObject();
+</#if>
 getJsonPrinter().endObject();

--- a/monticore-generator/src/main/resources/_symboltable/serialization/symbols2Json/Store.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/serialization/symbols2Json/Store.ftl
@@ -1,7 +1,5 @@
 <#-- (c) https://github.com/MontiCore/monticore -->
 ${tc.signature()}
-  getJsonPrinter().clearBuffer();
-  scope.accept(getTraverser());
-  String serialized = getJsonPrinter().getContent();
+  String serialized = this.serialize(scope);
   de.monticore.io.FileReaderWriter.storeInFile(java.nio.file.Paths.get(fileName), serialized);
   return serialized;

--- a/monticore-generator/src/main/resources/_symboltable/serialization/symbols2Json/WriteSymbolHierarchies.ftl
+++ b/monticore-generator/src/main/resources/_symboltable/serialization/symbols2Json/WriteSymbolHierarchies.ftl
@@ -1,0 +1,6 @@
+<#-- (c) https://github.com/MontiCore/monticore -->
+${tc.signature("symbolToSuperSymbolsMap")}
+// Store the symbol hierarchy within the exported JSON to adapt to unknown symbols of the target lang
+<#list symbolToSuperSymbolsMap as symbolClassName, superSymbolClassName>
+	getJsonPrinter().member(${symbolClassName}.class.getName(), ${superSymbolClassName}.class.getName());
+</#list>

--- a/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/serialization/ScopeDeSerDecoratorTest.java
+++ b/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/serialization/ScopeDeSerDecoratorTest.java
@@ -113,7 +113,7 @@ public class ScopeDeSerDecoratorTest extends DecoratorTestCase {
 
   @Test
   public void testAttributeCount() {
-    assertEquals(0, scopeClass.getCDAttributeList().size());
+    assertEquals(1, scopeClass.getCDAttributeList().size());
   
     assertTrue(Log.getFindings().isEmpty());
   }

--- a/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/serialization/ScopeDeSerDecoratorTest.java
+++ b/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/serialization/ScopeDeSerDecoratorTest.java
@@ -120,7 +120,7 @@ public class ScopeDeSerDecoratorTest extends DecoratorTestCase {
 
   @Test
   public void testMethodCount() {
-    assertEquals(21, scopeClass.getCDMethodList().size());
+    assertEquals(22, scopeClass.getCDMethodList().size());
   
     assertTrue(Log.getFindings().isEmpty());
   }

--- a/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/serialization/Symbols2JsonDecoratorTest.java
+++ b/monticore-generator/src/test/java/de/monticore/codegen/cd2java/_symboltable/serialization/Symbols2JsonDecoratorTest.java
@@ -157,7 +157,7 @@ public class Symbols2JsonDecoratorTest extends DecoratorTestCase {
 
   @Test
   public void testMethodCount(){
-    assertEquals(22, symbolTablePrinterClass.getCDMethodList().size());
+    assertEquals(23, symbolTablePrinterClass.getCDMethodList().size());
 
     assertTrue(Log.getFindings().isEmpty());
   }

--- a/monticore-generator/src/test/java/de/monticore/codegen/mc2cd/transl/SymbolAndScopeTranslationTest.java
+++ b/monticore-generator/src/test/java/de/monticore/codegen/mc2cd/transl/SymbolAndScopeTranslationTest.java
@@ -36,7 +36,7 @@ public class SymbolAndScopeTranslationTest extends TranslationTestCase {
     // only 2 because other one is the start prod stereotype
     assertEquals(2, astType.getModifier().getStereotype().getValuesList().size());
     assertEquals("symbol", astType.getModifier().getStereotype().getValues(0).getName());
-    assertTrue(astType.getModifier().getStereotype().getValues(0).getValue().isEmpty());
+    assertEquals("mc2cdtransformation.symbolandscopetranslation._symboltable.TypeSymbol", astType.getModifier().getStereotype().getValues(0).getValue());
     assertEquals("startProd", astType.getModifier().getStereotype().getValues(1).getName());
     assertTrue(astType.getModifier().getStereotype().getValues(1).getValue().isEmpty());
   
@@ -75,8 +75,8 @@ public class SymbolAndScopeTranslationTest extends TranslationTestCase {
     assertTrue(astType.getModifier().isPresentStereotype());
     assertEquals(1, astType.getModifier().getStereotype().getValuesList().size());
     assertEquals("symbol", astType.getModifier().getStereotype().getValues(0).getName());
-    assertTrue(astType.getModifier().getStereotype().getValues(0).getValue().isEmpty());
-  
+    assertEquals("mc2cdtransformation.symbolandscopetranslation._symboltable.SimpleSymbolClassSymbol", astType.getModifier().getStereotype().getValues(0).getValue());
+
     assertTrue(Log.getFindings().isEmpty());
   }
 

--- a/monticore-runtime/src/main/java/de/monticore/symboltable/serialization/JsonDeSers.java
+++ b/monticore-runtime/src/main/java/de/monticore/symboltable/serialization/JsonDeSers.java
@@ -33,6 +33,8 @@ public class JsonDeSers {
 
   public static final String STEREO_INFO = "stereoinfo";
 
+  public static final String SYMBOL_HIERARCHY = "symbolHierarchy";
+
   /**
    * This method deserializes a stored package. If no package is stored, the default
    * empty package ("") is returned.

--- a/monticore-test/02.experiments/dispatcher/src/test/java/ImplicitSymbolHierarchyTest.java
+++ b/monticore-test/02.experiments/dispatcher/src/test/java/ImplicitSymbolHierarchyTest.java
@@ -1,0 +1,158 @@
+/* (c) https://github.com/MontiCore/monticore */
+
+import bluea.BlueAMill;
+import bluea._symboltable.PlaceSymbol;
+import blueb.BlueBMill;
+import blueb._symboltable.BluePlaceSymbol;
+import blueb._symboltable.RedPlaceSymbol;
+import bluec.BlueCMill;
+import bluec._ast.ASTLightBluePlace;
+import bluec._symboltable.BlueCSymbols2Json;
+import bluec._symboltable.IBlueCArtifactScope;
+import bluec._symboltable.LightBluePlaceSymbol;
+import de.monticore.symboltable.serialization.JsonParser;
+import de.monticore.symboltable.serialization.json.JsonElement;
+import de.monticore.symboltable.serialization.json.JsonObject;
+import de.se_rwth.commons.logging.Log;
+import de.se_rwth.commons.logging.LogStub;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * This test ensures that unknown symbol kinds are implicitly adapted to their super-kinds.
+ * Thus, when resolving for a symbol of a kind, the kinds of (unknown) sublanguages are also present & loaded
+ */
+public class ImplicitSymbolHierarchyTest {
+
+
+  @TempDir
+  protected Path tempDir;
+
+  protected Path symbolTableFile;
+
+  @BeforeEach
+  public void before() throws IOException {
+    LogStub.init();
+    Log.enableFailQuick(false);
+
+    symbolTableFile = tempDir.resolve("LB1.bluec.sym");
+
+    BlueCMill.init();
+
+    Optional<ASTLightBluePlace> astOpt = BlueCMill.parser()
+            .parse_String("lightBluePlace LB1 { bluePlace B1 {} redPlace R1 {} }");
+    Assertions.assertTrue(astOpt.isPresent());
+
+    IBlueCArtifactScope st = BlueCMill.scopesGenitorDelegator().createFromAST(astOpt.get());
+
+    BlueCSymbols2Json blueCSymbols2Json = new BlueCSymbols2Json();
+    blueCSymbols2Json.store(st, symbolTableFile.toAbsolutePath().toString());
+
+    BlueCMill.reset();
+  }
+
+  @Test
+  public void testBlueC() throws IOException {
+    BlueCMill.init();
+    // We have to add the parent (not the file itself)
+    BlueCMill.globalScope().getSymbolPath().addEntry(tempDir);
+
+    Assertions.assertEquals(1, BlueCMill.globalScope().resolveLightBluePlaceMany("LB1").size());
+    Assertions.assertEquals(1, BlueCMill.globalScope().resolveBluePlaceMany("LB1").size());
+    Assertions.assertEquals(1, BlueBMill.globalScope().resolveBluePlaceMany("LB1").size()); // lang comp
+    Assertions.assertEquals(1, BlueCMill.globalScope().resolvePlaceMany("LB1").size());
+    Assertions.assertEquals(1, BlueBMill.globalScope().resolvePlaceMany("LB1").size()); // lang comp
+    Assertions.assertEquals(1, BlueAMill.globalScope().resolvePlaceMany("LB1").size()); // lang comp
+
+    Assertions.assertEquals(0, BlueCMill.globalScope().resolveLightBluePlaceMany("LB1.B1").size());
+    Assertions.assertEquals(1, BlueCMill.globalScope().resolveBluePlaceMany("LB1.B1").size());
+    Assertions.assertEquals(1, BlueBMill.globalScope().resolveBluePlaceMany("LB1.B1").size()); // lang comp
+    Assertions.assertEquals(1, BlueCMill.globalScope().resolvePlaceMany("LB1.B1").size());
+    Assertions.assertEquals(1, BlueBMill.globalScope().resolvePlaceMany("LB1.B1").size()); // lang comp
+    Assertions.assertEquals(1, BlueAMill.globalScope().resolvePlaceMany("LB1.B1").size()); // lang comp
+
+    Assertions.assertEquals(0, BlueCMill.globalScope().resolveLightBluePlaceMany("LB1.R1").size());
+    Assertions.assertEquals(1, BlueCMill.globalScope().resolveRedPlaceMany("LB1.R1").size());
+    Assertions.assertEquals(1, BlueBMill.globalScope().resolveRedPlaceMany("LB1.R1").size()); // lang comp
+    Assertions.assertEquals(1, BlueCMill.globalScope().resolvePlaceMany("LB1.R1").size());
+    Assertions.assertEquals(1, BlueBMill.globalScope().resolvePlaceMany("LB1.R1").size()); // lang comp
+    Assertions.assertEquals(1, BlueAMill.globalScope().resolvePlaceMany("LB1.R1").size()); // lang comp
+
+    BlueCMill.reset();
+  }
+
+  @Test
+  public void testBlueB() throws IOException {
+    BlueBMill.init();
+    // We have to add the parent (not the file itself)
+    BlueBMill.globalScope().getSymbolPath().addEntry(tempDir);
+
+    Assertions.assertEquals(1, BlueBMill.globalScope().resolveBluePlaceMany("LB1").size());
+    Assertions.assertEquals(1, BlueBMill.globalScope().resolvePlaceMany("LB1").size());
+    Assertions.assertEquals(1, BlueAMill.globalScope().resolvePlaceMany("LB1").size());
+
+    Assertions.assertEquals(1, BlueBMill.globalScope().resolveBluePlaceMany("LB1.B1").size());
+    Assertions.assertEquals(1, BlueBMill.globalScope().resolvePlaceMany("LB1.B1").size());
+    Assertions.assertEquals(1, BlueAMill.globalScope().resolvePlaceMany("LB1.B1").size()); // lang comp
+
+    Assertions.assertEquals(1, BlueBMill.globalScope().resolveRedPlaceMany("LB1.R1").size());
+    Assertions.assertEquals(1, BlueBMill.globalScope().resolvePlaceMany("LB1.R1").size());
+    Assertions.assertEquals(1, BlueAMill.globalScope().resolvePlaceMany("LB1.R1").size()); // lang comp
+
+    BlueBMill.reset();
+  }
+
+  @Test
+  public void testBlueA() throws IOException {
+    BlueAMill.init();
+    // We have to add the parent (not the file itself)
+    BlueAMill.globalScope().getSymbolPath().addEntry(tempDir);
+
+    Assertions.assertEquals(1, BlueAMill.globalScope().resolvePlaceMany("LB1").size());
+
+    Assertions.assertEquals(1, BlueAMill.globalScope().resolvePlaceMany("LB1.B1").size());
+
+    Assertions.assertEquals(1, BlueAMill.globalScope().resolvePlaceMany("LB1.R1").size());
+
+    BlueAMill.reset();
+  }
+
+
+  @Test
+  public void testJson() throws IOException {
+    JsonElement jsonST = JsonParser.parse(Files.readString(symbolTableFile));
+    Assertions.assertTrue(jsonST.isJsonObject());
+    Assertions.assertTrue(jsonST.getAsJsonObject().hasObjectMember("symbolHierarchy"));
+    JsonObject symbolHierarchy = jsonST.getAsJsonObject().getObjectMember("symbolHierarchy");
+
+    // C.LightBluePlaceSymbol -> B.BlueSymbol
+    Assertions.assertTrue(symbolHierarchy.hasStringMember(LightBluePlaceSymbol.class.getName()));
+    Assertions.assertEquals(BluePlaceSymbol.class.getName(),
+                            symbolHierarchy.getStringMember(LightBluePlaceSymbol.class.getName()));
+
+    // B.BluePlaceSymbol -> A.PlaceSymbol
+    Assertions.assertTrue(symbolHierarchy.hasStringMember(BluePlaceSymbol.class.getName()));
+    Assertions.assertEquals(PlaceSymbol.class.getName(),
+                            symbolHierarchy.getStringMember(BluePlaceSymbol.class.getName()));
+
+    // B.RedPlaceSymbol -> A.PlaceSymbol
+    Assertions.assertTrue(symbolHierarchy.hasStringMember(RedPlaceSymbol.class.getName()));
+    Assertions.assertEquals(PlaceSymbol.class.getName(),
+                            symbolHierarchy.getStringMember(RedPlaceSymbol.class.getName()));
+
+    Assertions.assertEquals(3, symbolHierarchy.sizeMembers());
+  }
+
+  @AfterEach
+  public void after() {
+    Log.getFindings().clear();
+  }
+}


### PR DESCRIPTION
* Fix missing symbol classname in `<<symbol>>` stereotype (now `<<symbol=a.b.MyTypeSymbol>>`)
* Implicitly adapt unknown symbol kinds (without requiring`globalScope().putOOTypeSymbolDeSer("..CDTypeSymbol")`)

- includes a test (+ transitive symbols)
* ToDo: Check if we have to update the tutorial?

closes https://git.rwth-aachen.de/monticore/monticore/-/work_items/4405 