### PR TITLE
Fix for list in opt

### DIFF
--- a/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatchingList.ftl
+++ b/monticore-runtime/src/main/resources/de/monticore/tf/odrules/DoPatternMatchingList.ftl
@@ -34,6 +34,10 @@ public boolean doPatternMatching_${structure.getObjectName()}(boolean isParentBa
 
     // SetUp Last Matching Process if ParentIsBacktracking
     if(isParentBacktracking) {
+      if (${structure.getObjectName()}_candidates == null) {
+         // the candidates were reset previously (list in opt?) -> we can't backtrace
+         return false;
+      }
       // Get Last List Object
       Match${structure.getObjectName()} match = ${structure.getObjectName()}_candidates.get(${structure.getObjectName()}_candidates.size()-1);
       ${structure.getObjectName()}_candidates.remove(${structure.getObjectName()}_candidates.size()-1);


### PR DESCRIPTION
Introduced when fixing the backtracking of 2+ lists.

Tests present here: https://git.rwth-aachen.de/monticore/montitrans/montitransruntime/-/blob/main/example/example-dsl/src/intTest/java/unifiedtest/SCLiteTest.java
* testBacktracking2xList
* testBacktrackingOptList