### PR TITLE
IOOSymbolsScope TC1 Hotfix

### DIFF
--- a/monticore-grammar/src/main/java/de/monticore/symbols/oosymbols/_symboltable/IOOSymbolsScope.java
+++ b/monticore-grammar/src/main/java/de/monticore/symbols/oosymbols/_symboltable/IOOSymbolsScope.java
@@ -7,6 +7,7 @@ import de.monticore.symboltable.IScopeSpanningSymbol;
 import de.monticore.symboltable.modifiers.AccessModifier;
 import de.monticore.symboltable.modifiers.StaticAccessModifier;
 import de.monticore.types.check.SymTypeExpression;
+import de.se_rwth.commons.logging.Log;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +28,8 @@ public  interface IOOSymbolsScope extends IOOSymbolsScopeTOP  {
     //resolve methods by using overridden method
     List<MethodSymbol> set = IOOSymbolsScopeTOP.super.resolveMethodLocallyMany(foundSymbols,name,modifier,predicate);
     if(this.isPresentSpanningSymbol()){
+      try {
+      // unsupported legacy implementation based on TC1 (to be replaced)
       IScopeSpanningSymbol spanningSymbol = getSpanningSymbol();
       //if the methodsymbol is in the spanned scope of a typesymbol then look for method in super types too
       if(spanningSymbol instanceof OOTypeSymbol){
@@ -35,6 +38,12 @@ public  interface IOOSymbolsScope extends IOOSymbolsScopeTOP  {
           t.getMethodList(name, false, modifier).stream().
                   filter(m -> m instanceof MethodSymbol).forEach(m -> set.add((MethodSymbol) m));
         }
+      }
+      } catch(UnsupportedOperationException e) {
+        Log.info("Legacy implementation run into an exception." +
+            "As it is not supported anymore, it is ignored",
+            e, "Resolving"
+        );
       }
     }
     return set;
@@ -51,6 +60,8 @@ public  interface IOOSymbolsScope extends IOOSymbolsScopeTOP  {
     //resolve methods by using overridden method
     List<FieldSymbol> result = IOOSymbolsScopeTOP.super.resolveFieldLocallyMany(foundSymbols,name,modifier,predicate);
     if(this.isPresentSpanningSymbol() && modifier.includes(StaticAccessModifier.NON_STATIC)){
+      try {
+      // unsupported legacy implementation based on TC1 (to be replaced)
       IScopeSpanningSymbol spanningSymbol = getSpanningSymbol();
       //if the fieldsymbol is in the spanned scope of a typesymbol then look for method in super types too
       if(spanningSymbol instanceof OOTypeSymbol){
@@ -60,6 +71,12 @@ public  interface IOOSymbolsScope extends IOOSymbolsScopeTOP  {
                  filter(f -> f instanceof FieldSymbol).forEach(f -> result.add((FieldSymbol) f));
         }
       }
+    } catch(UnsupportedOperationException e) {
+      Log.info("Legacy implementation run into an exception." +
+              "As it is not supported anymore, it is ignored",
+          e, "Resolving"
+      );
+    }
     }
     return result;
   }


### PR DESCRIPTION
TC1 is still used in the resolver and causes issues. Quick workaround instead of fix.