### PR TITLE
Do not capture errors from FTL 

### DIFF
--- a/monticore-runtime/src/main/java/de/monticore/generating/templateengine/freemarker/FreeMarkerTemplateEngine.java
+++ b/monticore-runtime/src/main/java/de/monticore/generating/templateengine/freemarker/FreeMarkerTemplateEngine.java
@@ -5,11 +5,9 @@ package de.monticore.generating.templateengine.freemarker;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
 import com.google.common.base.Preconditions;
-import de.se_rwth.commons.logging.Log;
 import freemarker.log.Logger;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
@@ -91,11 +89,22 @@ public class FreeMarkerTemplateEngine {
           causedExceptionInfo.append("\n").append(targetException);
         }
       }
-      throw new MontiCoreFreeMarkerException("0xA0561 Unable to execute template " + template.getName() + " : " +
+      MontiCoreFreeMarkerException mcFtlException = new MontiCoreFreeMarkerException("0xA0561 Unable to execute template " + template.getName() + " : " +
               e.getLocalizedMessage() +
               seperator + "Exception-type: " + e.getCause() + causedExceptionInfo.toString() +
               seperator + "Caused by " + seperator + e.getFTLInstructionStack(),
           e.getCause());
+      if (e.getCause() instanceof Error) {
+        // In case an error is thrown (such as MCFatalErrors), we omit setting
+        // the FTL context and instead pass the error directly along (to make errors readable)
+
+        // The MontiCoreFreeMarkerException/ftl context is added to the
+        // stacktrace as a suppressed exception
+        // (but does not modify the error message)
+        e.getCause().addSuppressed(mcFtlException);
+        throw (Error) e.getCause();
+      }
+      throw mcFtlException;
     }
     catch (IOException e) {
       throw new MontiCoreFreeMarkerException("0xA0563 Could not read template " + template.getName() + " : " + e.getLocalizedMessage() +


### PR DESCRIPTION
Do not wrap errors thrown in freemarker-invoked code/templates in a MontiCoreFreeMarkerException,
instead add the FTL-exception as suppressed to the error.

```diff
 > There was a failure while executing work items
   > A failure occurred while executing de.montigem.gradle.common.MGAction
-      > 0xA0561 Unable to execute template umlp.GUI2Java : Java method "umlp.generator.gui.genjava.decorator.GUI2JavaClassDecorator.transform(de.monticore.guidsl._ast.ASTGUICompilationUnit, de.monticore.cdbasis._ast.ASTCDCompilationUnit)" threw an exception when invoked on umlp.generator.gui.genjava.decorator.GUI2JavaClassDecorator object "umlp.generator.gui.genjava.decorator.GUI2JavaClassDecorator@68bb5e32"; see cause exception in the Java stack trace.  
+      > Runners.gui:<33,41> - Runners.gui:<33,74>: 0xB0163 Operator '+' not applicable to 'R"(( - )(.*))( )"', 'Optional<String>'

```

<details>

<summary>Diff of full output</summary>

```diff
diff --git "a/..\\..\\zzpre.txt" "b/..\\..\\zznew.txt"
index e3b1923..d755f4d 100644
--- "a/..\\..\\zzpre.txt"
+++ "b/..\\..\\zznew.txt"
@@ -1,7 +1,7 @@
 Execution failed for task ':montigem:frontend:gui2java2ts'.
 > There was a failure while executing work items
    > A failure occurred while executing de.montigem.gradle.common.MGAction
-      > 0xA0561 Unable to execute template umlp.GUI2Java : Java method "umlp.generator.gui.genjava.decorator.GUI2JavaClassDecorator.transform(de.monticore.guidsl._ast.ASTGUICompilationUnit, de.monticore.cdbasis._ast.ASTCDCompilationUnit)" threw an exception when invoked on umlp.generator.gui.genjava.decorator.GUI2JavaClassDecorator object "umlp.generator.gui.genjava.decorator.GUI2JavaClassDecorator@68bb5e32"; see cause exception in the Java stack trace.
+      > Runners.gui:<33,41> - Runners.gui:<33,74>: 0xB0163 Operator '+' not applicable to 'R"(( - )(.*))( )"', 'Optional<String>'
 
 * Try:
 > Run with --info or --debug option to get more log output.
@@ -307,63 +307,6 @@ Caused by: org.gradle.workers.internal.DefaultWorkerExecutor$WorkExecutionExcept
 	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:380)
 	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
 	at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:47)
-Caused by: de.monticore.generating.templateengine.freemarker.MontiCoreFreeMarkerException: 0xA0561 Unable to execute template umlp.GUI2Java : Java method "umlp.generator.gui.genjava.decorator.GUI2JavaClassDecorator.transform(de.monticore.guidsl._ast.ASTGUICompilationUnit, de.monticore.cdbasis._ast.ASTCDCompilationUnit)" threw an exception when invoked on umlp.generator.gui.genjava.decorator.GUI2JavaClassDecorator object "umlp.generator.gui.genjava.decorator.GUI2JavaClassDecorator@68bb5e32"; see cause exception in the Java stack trace.
-
-----
-FTL stack trace ("~" means nesting-related):
-	- Failed at: ${guiDecorator.transform(ast, decorat...  [in template "umlp.GUI2Java" at line 15, column 1]
-----nullException-type: de.se_rwth.commons.logging.MCFatalError: Runners.gui:<33,41> - Runners.gui:<33,74>: 0xB0163 Operator '+' not applicable to 'R"(( - )(.*))( )"', 'Optional<String>'nullCaused by null	- Failed at: ${guiDecorator.transform(ast, decorat...  [in template "umlp.GUI2Java" at line 15, column 1]
-
-	at de.monticore.generating.templateengine.freemarker.FreeMarkerTemplateEngine.run(FreeMarkerTemplateEngine.java:94)
-	at de.monticore.generating.templateengine.TemplateController.runInEngine(TemplateController.java:579)
-	at de.monticore.generating.templateengine.TemplateController.runInEngine(TemplateController.java:488)
-	at de.monticore.generating.templateengine.TemplateController.processTemplate(TemplateController.java:470)
-	at de.monticore.generating.templateengine.TemplateHookPoint.processValue(TemplateHookPoint.java:81)
-	at umlp.generator.gui.genjava.GUI2JavaGenerator.generate(GUI2JavaGenerator.java:31)
-	at umlp.cli.GuiPipeline.lambda$8(GuiPipeline.java:205)
-	at umlp.cli.common.IOperation$ISimpleOperation.doWork(IOperation.java:19)
-	at umlp.cli.common.Pipeline.doWork(Pipeline.java:73)
-	at umlp.cli.GuiPipeline.lambda$18(GuiPipeline.java:81)
-	at umlp.cli.common.IOperation$1.doWork(IOperation.java:52)
-	at umlp.cli.common.Pipeline.doWork(Pipeline.java:73)
-	at umlp.cli.common.Pipeline.doWork(Pipeline.java:73)
-	at umlp.UMLPTool.run(UMLPTool.java:210)
-	at umlp.UMLPTool.gradleMain(UMLPTool.java:157)
-	at de.montigem.gradle.common.UMLPToolInvoker.run(UMLPToolInvoker.java:23)
-	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
-	at de.monticore.gradle.internal.isolation.CachedIsolation.lambda$6(CachedIsolation.java:234)
-	at de.monticore.gradle.internal.isolation.CachedIsolation.executeInClassloader(CachedIsolation.java:223)
-	at de.monticore.gradle.internal.isolation.CachedIsolation$WithClassPath.executeInClassloader(CachedIsolation.java:528)
-	at de.montigem.gradle.common.MGAction.doRun(MGAction.java:18)
-	at de.monticore.gradle.common.AToolAction.execute(AToolAction.java:38)
-	at org.gradle.workers.internal.DefaultWorkerServer.execute(DefaultWorkerServer.java:63)
-	at org.gradle.workers.internal.NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:66)
-	at org.gradle.workers.internal.NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:62)
-	at org.gradle.internal.classloader.ClassLoaderUtils.executeInClassloader(ClassLoaderUtils.java:100)
-	at org.gradle.workers.internal.NoIsolationWorkerFactory$1.lambda$execute$0(NoIsolationWorkerFactory.java:62)
-	at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:44)
-	at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:41)
-	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
-	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
-	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
-	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
-	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
-	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
-	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
-	at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
-	at org.gradle.workers.internal.AbstractWorker.executeWrappedInBuildOperation(AbstractWorker.java:41)
-	at org.gradle.workers.internal.NoIsolationWorkerFactory$1.execute(NoIsolationWorkerFactory.java:59)
-	at org.gradle.workers.internal.DefaultWorkerExecutor.lambda$submitWork$0(DefaultWorkerExecutor.java:170)
-	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runExecution(DefaultConditionalExecutionQueue.java:187)
-	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.access$700(DefaultConditionalExecutionQueue.java:120)
-	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner$1.run(DefaultConditionalExecutionQueue.java:162)
-	at org.gradle.internal.Factories$1.create(Factories.java:31)
-	at org.gradle.internal.work.DefaultWorkerLeaseService.withLocks(DefaultWorkerLeaseService.java:264)
-	at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:128)
-	at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:133)
-	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runBatch(DefaultConditionalExecutionQueue.java:157)
-	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.run(DefaultConditionalExecutionQueue.java:126)
-	... 2 more
 Caused by: de.se_rwth.commons.logging.MCFatalError: Runners.gui:<33,41> - Runners.gui:<33,74>: 0xB0163 Operator '+' not applicable to 'R"(( - )(.*))( )"', 'Optional<String>'
 	at de.monticore.gradle.common.GradleErrorHook.terminate(GradleErrorHook.java:20)
 	at de.se_rwth.commons.logging.Log.terminateIfErrors(Log.java:983)
@@ -475,11 +418,124 @@ Caused by: de.se_rwth.commons.logging.MCFatalError: Runners.gui:<33,41> - Runner
 	at freemarker.core.Environment.visit(Environment.java:350)
 	at freemarker.core.Environment.process(Environment.java:323)
 	at freemarker.template.Template.process(Template.java:383)
-	at de.monticore.generating.templateengine.freemarker.FreeMarkerTemplateEngine.run(FreeMarkerTemplateEngine.java:78)
-	... 50 more
+	at de.monticore.generating.templateengine.freemarker.FreeMarkerTemplateEngine.run(FreeMarkerTemplateEngine.java:79)
+	at de.monticore.generating.templateengine.TemplateController.runInEngine(TemplateController.java:579)
+	at de.monticore.generating.templateengine.TemplateController.runInEngine(TemplateController.java:488)
+	at de.monticore.generating.templateengine.TemplateController.processTemplate(TemplateController.java:470)
+	at de.monticore.generating.templateengine.TemplateHookPoint.processValue(TemplateHookPoint.java:81)
+	at umlp.generator.gui.genjava.GUI2JavaGenerator.generate(GUI2JavaGenerator.java:31)
+	at umlp.cli.GuiPipeline.lambda$8(GuiPipeline.java:205)
+	at umlp.cli.common.IOperation$ISimpleOperation.doWork(IOperation.java:19)
+	at umlp.cli.common.Pipeline.doWork(Pipeline.java:73)
+	at umlp.cli.GuiPipeline.lambda$18(GuiPipeline.java:81)
+	at umlp.cli.common.IOperation$1.doWork(IOperation.java:52)
+	at umlp.cli.common.Pipeline.doWork(Pipeline.java:73)
+	at umlp.cli.common.Pipeline.doWork(Pipeline.java:73)
+	at umlp.UMLPTool.run(UMLPTool.java:210)
+	at umlp.UMLPTool.gradleMain(UMLPTool.java:157)
+	at de.montigem.gradle.common.UMLPToolInvoker.run(UMLPToolInvoker.java:23)
+	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
+	at de.monticore.gradle.internal.isolation.CachedIsolation.lambda$6(CachedIsolation.java:234)
+	at de.monticore.gradle.internal.isolation.CachedIsolation.executeInClassloader(CachedIsolation.java:223)
+	at de.monticore.gradle.internal.isolation.CachedIsolation$WithClassPath.executeInClassloader(CachedIsolation.java:528)
+	at de.montigem.gradle.common.MGAction.doRun(MGAction.java:18)
+	at de.monticore.gradle.common.AToolAction.execute(AToolAction.java:38)
+	at org.gradle.workers.internal.DefaultWorkerServer.execute(DefaultWorkerServer.java:63)
+	at org.gradle.workers.internal.NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:66)
+	at org.gradle.workers.internal.NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:62)
+	at org.gradle.internal.classloader.ClassLoaderUtils.executeInClassloader(ClassLoaderUtils.java:100)
+	at org.gradle.workers.internal.NoIsolationWorkerFactory$1.lambda$execute$0(NoIsolationWorkerFactory.java:62)
+	at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:44)
+	at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:41)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
+	at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
+	at org.gradle.workers.internal.AbstractWorker.executeWrappedInBuildOperation(AbstractWorker.java:41)
+	at org.gradle.workers.internal.NoIsolationWorkerFactory$1.execute(NoIsolationWorkerFactory.java:59)
+	at org.gradle.workers.internal.DefaultWorkerExecutor.lambda$submitWork$0(DefaultWorkerExecutor.java:170)
+	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runExecution(DefaultConditionalExecutionQueue.java:187)
+	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.access$700(DefaultConditionalExecutionQueue.java:120)
+	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner$1.run(DefaultConditionalExecutionQueue.java:162)
+	at org.gradle.internal.Factories$1.create(Factories.java:31)
+	at org.gradle.internal.work.DefaultWorkerLeaseService.withLocks(DefaultWorkerLeaseService.java:264)
+	at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:128)
+	at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:133)
+	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runBatch(DefaultConditionalExecutionQueue.java:157)
+	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.run(DefaultConditionalExecutionQueue.java:126)
+	... 2 more
+	Suppressed: de.monticore.generating.templateengine.freemarker.MontiCoreFreeMarkerException: 0xA0561 Unable to execute template umlp.GUI2Java : Java method "umlp.generator.gui.genjava.decorator.GUI2JavaClassDecorator.transform(de.monticore.guidsl._ast.ASTGUICompilationUnit, de.monticore.cdbasis._ast.ASTCDCompilationUnit)" threw an exception when invoked on umlp.generator.gui.genjava.decorator.GUI2JavaClassDecorator object "umlp.generator.gui.genjava.decorator.GUI2JavaClassDecorator@60632342"; see cause exception in the Java stack trace.
 
+----
+FTL stack trace ("~" means nesting-related):
+	- Failed at: ${guiDecorator.transform(ast, decorat...  [in template "umlp.GUI2Java" at line 15, column 1]
+----nullException-type: de.se_rwth.commons.logging.MCFatalError: Runners.gui:<33,41> - Runners.gui:<33,74>: 0xB0163 Operator '+' not applicable to 'R"(( - )(.*))( )"', 'Optional<String>'nullCaused by null	- Failed at: ${guiDecorator.transform(ast, decorat...  [in template "umlp.GUI2Java" at line 15, column 1]
 
-BUILD FAILED in 3m 40s
-16 actionable tasks: 10 executed, 6 up-to-date
+		at de.monticore.generating.templateengine.freemarker.FreeMarkerTemplateEngine.run(FreeMarkerTemplateEngine.java:95)
+		at de.monticore.generating.templateengine.TemplateController.runInEngine(TemplateController.java:579)
+		at de.monticore.generating.templateengine.TemplateController.runInEngine(TemplateController.java:488)
+		at de.monticore.generating.templateengine.TemplateController.processTemplate(TemplateController.java:470)
+		at de.monticore.generating.templateengine.TemplateHookPoint.processValue(TemplateHookPoint.java:81)
+		at umlp.generator.gui.genjava.GUI2JavaGenerator.generate(GUI2JavaGenerator.java:31)
+		at umlp.cli.GuiPipeline.lambda$8(GuiPipeline.java:205)
+		at umlp.cli.common.IOperation$ISimpleOperation.doWork(IOperation.java:19)
+		at umlp.cli.common.Pipeline.doWork(Pipeline.java:73)
+		at umlp.cli.GuiPipeline.lambda$18(GuiPipeline.java:81)
+		at umlp.cli.common.IOperation$1.doWork(IOperation.java:52)
+		at umlp.cli.common.Pipeline.doWork(Pipeline.java:73)
+		at umlp.cli.common.Pipeline.doWork(Pipeline.java:73)
+		at umlp.UMLPTool.run(UMLPTool.java:210)
+		at umlp.UMLPTool.gradleMain(UMLPTool.java:157)
+		at de.montigem.gradle.common.UMLPToolInvoker.run(UMLPToolInvoker.java:23)
+		at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
+		at java.base/java.lang.reflect.Method.invoke(Method.java:580)
+		at de.monticore.gradle.internal.isolation.CachedIsolation.lambda$6(CachedIsolation.java:234)
+		at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
+		at de.monticore.gradle.internal.isolation.CachedIsolation.executeInClassloader(CachedIsolation.java:223)
+		at de.monticore.gradle.internal.isolation.CachedIsolation$WithClassPath.executeInClassloader(CachedIsolation.java:528)
+		at de.montigem.gradle.common.MGAction.doRun(MGAction.java:18)
+		at de.monticore.gradle.common.AToolAction.execute(AToolAction.java:38)
+		at org.gradle.workers.internal.DefaultWorkerServer.execute(DefaultWorkerServer.java:63)
+		at org.gradle.workers.internal.NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:66)
+		at org.gradle.workers.internal.NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:62)
+		at org.gradle.internal.classloader.ClassLoaderUtils.executeInClassloader(ClassLoaderUtils.java:100)
+		at org.gradle.workers.internal.NoIsolationWorkerFactory$1.lambda$execute$0(NoIsolationWorkerFactory.java:62)
+		at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:44)
+		at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:41)
+		at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
+		at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
+		at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
+		at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
+		at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
+		at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
+		at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
+		at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
+		at org.gradle.workers.internal.AbstractWorker.executeWrappedInBuildOperation(AbstractWorker.java:41)
+		at org.gradle.workers.internal.NoIsolationWorkerFactory$1.execute(NoIsolationWorkerFactory.java:59)
+		at org.gradle.workers.internal.DefaultWorkerExecutor.lambda$submitWork$0(DefaultWorkerExecutor.java:170)
+		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
+		at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runExecution(DefaultConditionalExecutionQueue.java:187)
+		at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.access$700(DefaultConditionalExecutionQueue.java:120)
+		at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner$1.run(DefaultConditionalExecutionQueue.java:162)
+		at org.gradle.internal.Factories$1.create(Factories.java:31)
+		at org.gradle.internal.work.DefaultWorkerLeaseService.withLocks(DefaultWorkerLeaseService.java:264)
+		at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:128)
+		at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:133)
+		at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runBatch(DefaultConditionalExecutionQueue.java:157)
+		at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.run(DefaultConditionalExecutionQueue.java:126)
+		at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
+		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
+		at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
+		at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:47)
+		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
+		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
+		at java.base/java.lang.Thread.run(Thread.java:1583)
+	Caused by: [CIRCULAR REFERENCE: de.se_rwth.commons.logging.MCFatalError: Runners.gui:<33,41> - Runners.gui:<33,74>: 0xB0163 Operator '+' not applicable to 'R"(( - )(.*))( )"', 'Optional<String>']
 
 
+BUILD FAILED in 3m 14s
+16 actionable tasks: 9 executed, 7 up-to-date

```

</details>
