### PR TITLE
Adapt interpretation of field access expression as Type names

### DIFF
--- a/monticore-grammar/src/main/java/de/monticore/expressions/commonexpressions/types3/CommonExpressionsTypeVisitor.java
+++ b/monticore-grammar/src/main/java/de/monticore/expressions/commonexpressions/types3/CommonExpressionsTypeVisitor.java
@@ -752,7 +752,7 @@ public class CommonExpressionsTypeVisitor extends AbstractTypeVisitor
    */
   protected void calculateFieldAccessFirstName(ASTNameExpression expr) {
     Optional<SymTypeExpression> nameAsExprType =
-        calculateExprQName(expr, false);
+        calculateExprQName(expr, true);
     Optional<SymTypeExpression> nameAsTypeIdType =
         calculateTypeIdQName(expr);
 
@@ -760,22 +760,7 @@ public class CommonExpressionsTypeVisitor extends AbstractTypeVisitor
       // here there is no need for type inference
       getType4Ast().setTypeOfExpression(expr, nameAsExprType.get());
     }
-
-    // Check if there is a second possible interpretation as Type Identifier
-    Optional<SymTypeExpression> nameAsExprTypeOptional =
-        nameAsTypeIdType.isPresent() ?
-            calculateExprQName(expr, true) : Optional.empty();
-
-    boolean nameIsExprAndType =
-        nameAsExprType.isPresent() &&
-            nameAsExprTypeOptional.isPresent() &&
-            nameAsTypeIdType.isPresent() &&
-            !nameAsExprType.get().deepEquals(nameAsExprTypeOptional.get()) &&
-            nameAsExprTypeOptional.get().deepEquals(nameAsTypeIdType.get());
-
-    if (nameAsTypeIdType.isPresent() &&
-        (nameAsExprType.isEmpty() || nameIsExprAndType)
-    ) {
+    if (nameAsTypeIdType.isPresent()) {
       getType4Ast().setTypeOfTypeIdentifierForName(
           expr,
           nameAsTypeIdType.get()

--- a/monticore-grammar/src/main/java/de/monticore/expressions/commonexpressions/types3/CommonExpressionsTypeVisitor.java
+++ b/monticore-grammar/src/main/java/de/monticore/expressions/commonexpressions/types3/CommonExpressionsTypeVisitor.java
@@ -611,9 +611,7 @@ public class CommonExpressionsTypeVisitor extends AbstractTypeVisitor
       if (expr.getExpression() instanceof ASTFieldAccessExpression) {
         ASTFieldAccessExpression innerFieldAccessExpr =
             (ASTFieldAccessExpression) (expr.getExpression());
-        fieldAccessCustomTraverse(
-            innerFieldAccessExpr
-        );
+        fieldAccessCustomTraverse(innerFieldAccessExpr);
         // if expression or type identifier has been found,
         // continue to require further results
         if (!getType4Ast().hasTypeOfExpression(innerFieldAccessExpr.getExpression()) &&
@@ -686,8 +684,9 @@ public class CommonExpressionsTypeVisitor extends AbstractTypeVisitor
         isSeriesOfNames(expr.getExpression()) &&
             getType4Ast().hasTypeOfTypeIdentifierForName(expr.getExpression());
     // case: typeIdentifier "." name, e.g., XClass.staticVar
-    // in Java, if a variable exists, the type identifier is not retained as an
-    // alternative and therefore remains ignored.
+    // in Java, if a variable exists,
+    // the type identifier is not retained as an alternative
+    // and therefore remains ignored.
     if (innerIsTypeIdentifier) {
       exprType = calculateTypeIdFieldAccessOrLogError(expr,
           innerIsExpression ||

--- a/monticore-grammar/src/main/java/de/monticore/expressions/commonexpressions/types3/CommonExpressionsTypeVisitor.java
+++ b/monticore-grammar/src/main/java/de/monticore/expressions/commonexpressions/types3/CommonExpressionsTypeVisitor.java
@@ -680,24 +680,32 @@ public class CommonExpressionsTypeVisitor extends AbstractTypeVisitor
     // after the non-visitor traversal, types have been calculated if they exist
     Optional<SymTypeExpression> exprType;
     Optional<SymTypeExpression> typeId = Optional.empty();
-    // case: expression "." name, e.g., getX().var
-    if (getType4Ast().hasTypeOfExpression(expr.getExpression())) {
-      exprType = calculateExprFieldAccessOrLogError(expr, false);
-    }
+    boolean innerIsExpression =
+        getType4Ast().hasTypeOfExpression(expr.getExpression());
+    boolean innerIsTypeIdentifier =
+        isSeriesOfNames(expr.getExpression()) &&
+            getType4Ast().hasTypeOfTypeIdentifierForName(expr.getExpression());
     // case: typeIdentifier "." name, e.g., XClass.staticVar
-    // in Java, if variable exists, typeIdentifier "." name is ignored,
-    // even if variable "." name does not exist
-    else if (getType4Ast().hasTypeOfTypeIdentifierForName(expr.getExpression())) {
+    // in Java, if a variable exists, the type identifier is not retained as an
+    // alternative and therefore remains ignored.
+    if (innerIsTypeIdentifier) {
       exprType = calculateTypeIdFieldAccessOrLogError(expr,
-          expectedResult != FieldAccessExpectedResult.EXPRESSION_TYPE);
+          innerIsExpression ||
+              expectedResult != FieldAccessExpectedResult.EXPRESSION_TYPE);
       // case: typeid "." typeid2 ("." name), e.g., C1.CInner.staticVar
       if (exprType.isEmpty() && expectedResult != FieldAccessExpectedResult.EXPRESSION_TYPE) {
-        // always expecting a result here, as we tried expressions already
-        typeId = calculateInnerTypeIdFieldAccessOrLogError(expr, false);
+        typeId = calculateInnerTypeIdFieldAccessOrLogError(expr, innerIsExpression);
       }
     }
-    // case: qualifier "." name
     else {
+      exprType = Optional.empty();
+    }
+    // case: expression "." name, e.g., getX().var
+    if (exprType.isEmpty() && typeId.isEmpty() && innerIsExpression) {
+      exprType = calculateExprFieldAccessOrLogError(expr, false);
+    }
+    // case: qualifier "." name
+    else if (!innerIsExpression && !innerIsTypeIdentifier) {
       // case: qualifier "." name as Expression
       exprType = calculateExprQNameOrLogError(expr,
           expectedResult != FieldAccessExpectedResult.EXPRESSION_TYPE);
@@ -745,14 +753,30 @@ public class CommonExpressionsTypeVisitor extends AbstractTypeVisitor
    */
   protected void calculateFieldAccessFirstName(ASTNameExpression expr) {
     Optional<SymTypeExpression> nameAsExprType =
-        calculateExprQName(expr);
+        calculateExprQName(expr, false);
     Optional<SymTypeExpression> nameAsTypeIdType =
         calculateTypeIdQName(expr);
+
     if (nameAsExprType.isPresent()) {
       // here there is no need for type inference
       getType4Ast().setTypeOfExpression(expr, nameAsExprType.get());
     }
-    else if (nameAsTypeIdType.isPresent()) {
+
+    // Check if there is a second possible interpretation as Type Identifier
+    Optional<SymTypeExpression> nameAsExprTypeOptional =
+        nameAsTypeIdType.isPresent() ?
+            calculateExprQName(expr, true) : Optional.empty();
+
+    boolean nameIsExprAndType =
+        nameAsExprType.isPresent() &&
+            nameAsExprTypeOptional.isPresent() &&
+            nameAsTypeIdType.isPresent() &&
+            !nameAsExprType.get().deepEquals(nameAsExprTypeOptional.get()) &&
+            nameAsExprTypeOptional.get().deepEquals(nameAsTypeIdType.get());
+
+    if (nameAsTypeIdType.isPresent() &&
+        (nameAsExprType.isEmpty() || nameIsExprAndType)
+    ) {
       getType4Ast().setTypeOfTypeIdentifierForName(
           expr,
           nameAsTypeIdType.get()
@@ -1072,7 +1096,8 @@ public class CommonExpressionsTypeVisitor extends AbstractTypeVisitor
       type = WithinScopeBasicSymbolsResolver
           .resolveNameAsExpr(
               getAsBasicSymbolsScope(expr.getEnclosingScope()),
-              nameOpt.get()
+              nameOpt.get(),
+              resultsAreOptional
           );
     }
     else {
@@ -1086,9 +1111,19 @@ public class CommonExpressionsTypeVisitor extends AbstractTypeVisitor
    */
   protected Optional<SymTypeExpression> calculateExprQName(
       ASTNameExpression expr) {
+    return calculateExprQName(expr, false);
+  }
+
+  /**
+   * calculates "a" as expression
+   */
+  protected Optional<SymTypeExpression> calculateExprQName(
+      ASTNameExpression expr,
+      boolean resultsAreOptional) {
     return WithinScopeBasicSymbolsResolver.resolveNameAsExpr(
         getAsBasicSymbolsScope(expr.getEnclosingScope()),
-        expr.getName()
+        expr.getName(),
+        resultsAreOptional
     );
   }
 

--- a/monticore-grammar/src/main/java/de/monticore/types3/util/WithinScopeBasicSymbolsResolver.java
+++ b/monticore-grammar/src/main/java/de/monticore/types3/util/WithinScopeBasicSymbolsResolver.java
@@ -62,7 +62,33 @@ public class WithinScopeBasicSymbolsResolver {
   public static Optional<SymTypeExpression> resolveNameAsExpr(
       IBasicSymbolsScope enclosingScope,
       String name) {
-    return getDelegate()._resolveNameAsExpr(enclosingScope, name);
+    return resolveNameAsExpr(enclosingScope, name, false);
+  }
+
+  /**
+   * resolves the name as an expression (variable or function)
+   *
+   * @param resultsAreOptional whether an empty result is expected by the caller
+   */
+  public static Optional<SymTypeExpression> resolveNameAsExpr(
+      IBasicSymbolsScope enclosingScope,
+      String name,
+      boolean resultsAreOptional) {
+    return getDelegate()._resolveNameAsExpr(
+        enclosingScope,
+        name,
+        resultsAreOptional
+    );
+  }
+
+  /**
+   * Extension point for resolvers that handle optional results differently.
+   */
+  protected Optional<SymTypeExpression> _resolveNameAsExpr(
+      IBasicSymbolsScope enclosingScope,
+      String name,
+      boolean resultsAreOptional) {
+    return _resolveNameAsExpr(enclosingScope, name);
   }
 
   protected Optional<SymTypeExpression> _resolveNameAsExpr(

--- a/monticore-grammar/src/test/java/de/monticore/types3/util/WithinScopeBasicSymbolsResolverTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/types3/util/WithinScopeBasicSymbolsResolverTest.java
@@ -1,0 +1,47 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.types3.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
+import de.monticore.symbols.basicsymbols._symboltable.IBasicSymbolsScope;
+import de.monticore.types.check.SymTypeExpression;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class WithinScopeBasicSymbolsResolverTest {
+
+  @AfterEach
+  void resetResolver() {
+    WithinScopeBasicSymbolsResolver.reset();
+  }
+
+  @Test
+  void delegatesWhetherResultsAreOptional() {
+    OptionalResultResolver resolver = new OptionalResultResolver();
+    WithinScopeBasicSymbolsResolver.setDelegate(resolver);
+    IBasicSymbolsScope scope = BasicSymbolsMill.scope();
+
+    WithinScopeBasicSymbolsResolver.resolveNameAsExpr(scope, "mandatory");
+    assertFalse(resolver.resultsAreOptional);
+
+    WithinScopeBasicSymbolsResolver.resolveNameAsExpr(scope, "optional", true);
+    assertTrue(resolver.resultsAreOptional);
+  }
+
+  protected static class OptionalResultResolver extends WithinScopeBasicSymbolsResolver {
+
+    protected boolean resultsAreOptional;
+
+    @Override
+    protected Optional<SymTypeExpression> _resolveNameAsExpr(
+        IBasicSymbolsScope enclosingScope,
+        String name,
+        boolean resultsAreOptional) {
+      this.resultsAreOptional = resultsAreOptional;
+      return Optional.empty();
+    }
+  }
+}


### PR DESCRIPTION
By giving more information to downstream languages, OCL can interpret Person in two different ways: `forall p in Person` and `Person.someStaticField`