### PR TITLE
Cleanup se-commons versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,10 +19,14 @@ org.gradle.caching=true
 # versions used
 version=7.9.0-SNAPSHOT
 previous_mc_version=7.8.0
+previous_se_commons_version=7.8.0
+previous_cd4a_version=7.8.0
 
-cd4a_version=7.8.0
+se_commons_version=7.9.0-SNAPSHOT
+se_gradle_version=7.9.0-SNAPSHOT
+
 mlc_version=7.8.0
-se_commons_version=7.8.0
+
 
 antlr_version=4.12.0
 junit_version=6.0.3

--- a/monticore-generator/build.gradle
+++ b/monticore-generator/build.gradle
@@ -41,9 +41,9 @@ allprojects {
 
 dependencies {
     implementation "de.monticore:monticore-grammar:$previous_mc_version"
-    implementation "de.se_rwth.commons:se-commons-groovy:$se_commons_version"
-    implementation "de.se_rwth.commons:se-commons-logging:$se_commons_version"
-    implementation "de.se_rwth.commons:se-commons-gradle:$se_gradle_version"
+    implementation "de.se_rwth.commons:se-commons-groovy:$previous_se_commons_version"
+    implementation "de.se_rwth.commons:se-commons-logging:$previous_se_commons_version"
+    implementation "de.se_rwth.commons:se-commons-gradle:$se_commons_version" // use the current version here
 
     implementation "org.apache.commons:commons-lang3:$commons_lang3_version"
     implementation "org.freemarker:freemarker:$freemarker_version"
@@ -54,7 +54,7 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic:[1.2.9,1.3.0)' // we appear to be incompatible with logback >= 1.3.0
     implementation 'ch.qos.logback:logback-core:[1.2.9,1.3.0)'
 
-    implementation "de.monticore.lang:cd4analysis:$cd4a_version"
+    implementation "de.monticore.lang:cd4analysis:$previous_cd4a_version"
     implementation "org.antlr:antlr4:$antlr_version"
     implementation "org.apache.groovy:groovy:$groovy_version"
     implementation "com.google.guava:guava:$guava_version"

--- a/monticore-generator/gradle-plugin/build.gradle
+++ b/monticore-generator/gradle-plugin/build.gradle
@@ -18,7 +18,7 @@ configurations {
 
 dependencies {
   implementation gradleApi()
-  implementation "de.se_rwth.commons:se-commons-gradle:$se_gradle_version" // use current version of the gradle-dependency
+  implementation "de.se_rwth.commons:se-commons-gradle:$se_commons_version" // use current version of the gradle-dependency
   implementation "de.monticore:monticore-runtime:$previous_mc_version" // Required due to json -> substitute this to remove the runtime from the gradle projects classpath
   mcTool project(":") // depend on the generator subproject
 

--- a/monticore-generator/gradle-plugin/build.gradle
+++ b/monticore-generator/gradle-plugin/build.gradle
@@ -18,7 +18,9 @@ configurations {
 
 dependencies {
   implementation gradleApi()
-  implementation "de.se_rwth.commons:se-commons-gradle:$se_commons_version" // use current version of the gradle-dependency
+  implementation ("de.se_rwth.commons:se-commons-gradle:$se_commons_version") { // use current version of the gradle-dependency
+    transitive = false // to avoid leaking the newer logging/utilities versions
+  }
   implementation "de.monticore:monticore-runtime:$previous_mc_version" // Required due to json -> substitute this to remove the runtime from the gradle projects classpath
   mcTool project(":") // depend on the generator subproject
 

--- a/monticore-generator/gradle.properties
+++ b/monticore-generator/gradle.properties
@@ -11,10 +11,12 @@ showTestOutput=false
 # versions used
 version=7.9.0-SNAPSHOT
 previous_mc_version=7.8.0
+previous_se_commons_version=7.8.0
+previous_cd4a_version=7.8.0
 
-cd4a_version=7.8.0
-se_commons_version=7.8.0
+se_commons_version=7.9.0-SNAPSHOT
 se_gradle_version=7.9.0-SNAPSHOT
+
 
 antlr_version=4.12.0
 junit_version=6.0.3

--- a/monticore-test/01.experiments/forParser/build.gradle
+++ b/monticore-test/01.experiments/forParser/build.gradle
@@ -7,7 +7,7 @@ dependencies {
   implementation group:'de.monticore', name:'monticore-runtime', version:previous_mc_version
   implementation 'de.se_rwth.commons:se-commons-logging:' + se_commons_version
   implementation group:'de.monticore', name:'monticore-grammar', version:previous_mc_version, classifier:"grammars"
-  implementation group:'de.monticore.lang', name:'cd4analysis', version:cd4a_version
+  implementation group:'de.monticore.lang', name:'cd4analysis', version:previous_cd4a_version
   implementation ("com.google.guava:guava:$guava_version!!")
   implementation project(path: ':monticore-runtime')
 }

--- a/monticore-test/02.experiments/build.gradle
+++ b/monticore-test/02.experiments/build.gradle
@@ -14,7 +14,6 @@ subprojects {
   ext.outDir = "$buildDir/generated-sources/monticore/sourcecode"
   
   dependencies {
-    implementation "de.se_rwth.commons:se-commons-utilities:$se_commons_version"
     implementation project(':monticore-runtime')
     implementation project(':monticore-grammar')
     grammar (project(path: ':monticore-grammar')){

--- a/monticore-test/example/build.gradle
+++ b/monticore-test/example/build.gradle
@@ -10,7 +10,6 @@ version = '1.0.0-SNAPSHOT'
 
 buildDir = file("$projectDir/target")
 def mcversion  = '7.1.0'
-def se_commons_version = '7.1.1-SNAPSHOT'
 def grammarName = 'Automata'
 def outDir = "$buildDir/generated-sources/"
 
@@ -18,7 +17,6 @@ dependencies {
   implementation "de.monticore:monticore-runtime:$mcversion"
   implementation "de.monticore:monticore-grammar:$mcversion"
   grammar "de.monticore:monticore-grammar:$mcversion:grammars"
-  implementation "de.se_rwth.commons:se-commons-utilities:$se_commons_version"
   testImplementation "junit:junit:4.13.1"
 }
 

--- a/monticore-test/it/build.gradle
+++ b/monticore-test/it/build.gradle
@@ -17,7 +17,6 @@ sonarqube {
 dependencies {
   implementation project(':monticore-runtime')
   implementation project(':monticore-grammar')
-  implementation "de.se_rwth.commons:se-commons-utilities:$se_commons_version"
 //  implementation project (':monticore-generator')
   testImplementation testFixtures(project(':monticore-runtime'))
   testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"

--- a/monticore-test/monticore-grammar-it/build.gradle
+++ b/monticore-test/monticore-grammar-it/build.gradle
@@ -15,7 +15,6 @@ configurations {grammar}
 dependencies {
   implementation project(':monticore-runtime')
   implementation project(':monticore-grammar')
-  implementation "de.se_rwth.commons:se-commons-utilities:$se_commons_version"
   testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
   testImplementation "org.junit.jupiter:junit-jupiter-engine:$junit_version"
   testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junit_version"

--- a/prepare-next-release/0001-use-next-snapshot.patch
+++ b/prepare-next-release/0001-use-next-snapshot.patch
@@ -8,44 +8,40 @@ diff --git a/gradle.properties b/gradle.properties
 index cb9de09ab..3fdc12ea2 100644
 --- a/gradle.properties
 +++ b/gradle.properties
-@@ -17,12 +17,12 @@ org.gradle.caching=true
+@@ -17,10 +17,10 @@ org.gradle.caching=true
  # org.gradle.caching.debug=true
  
  # versions used
 -version=7.9.0-SNAPSHOT
 -previous_mc_version=7.8.0
+-previous_se_commons_version=7.8.0
+-previous_cd4a_version=7.8.0
 +version=7.10.0-SNAPSHOT
 +previous_mc_version=7.9.0-SNAPSHOT
- 
--cd4a_version=7.8.0
--mlc_version=7.8.0
--se_commons_version=7.8.0
-+cd4a_version=7.9.0-SNAPSHOT
-+mlc_version=7.9.0-SNAPSHOT
-+se_commons_version=7.9.0-SNAPSHOT
- 
- antlr_version=4.12.0
- junit_version=6.0.3
++previous_se_commons_version=7.9.0-SNAPSHOT
++previous_cd4a_version=7.9.0-SNAPSHOT
+
+ se_commons_version=7.9.0-SNAPSHOT
+ se_gradle_version=7.9.0-SNAPSHOT
 diff --git a/monticore-generator/gradle.properties b/monticore-generator/gradle.properties
-index d54bbbd2c..557baba04 100644
+index 051fc5951..4db170dd0 100644
 --- a/monticore-generator/gradle.properties
 +++ b/monticore-generator/gradle.properties
-@@ -9,11 +9,11 @@ useLocalRepo=false
+@@ -9,10 +9,10 @@ useLocalRepo=false
  showTestOutput=false
  
  # versions used
 -version=7.9.0-SNAPSHOT
 -previous_mc_version=7.8.0
+-previous_se_commons_version=7.8.0
+-previous_cd4a_version=7.8.0
 +version=7.10.0-SNAPSHOT
 +previous_mc_version=7.9.0-SNAPSHOT
- 
--cd4a_version=7.8.0
--se_commons_version=7.8.0
-+cd4a_version=7.9.0-SNAPSHOT
-+se_commons_version=7.9.0-SNAPSHOT
++previous_se_commons_version=7.9.0-SNAPSHOT
++previous_cd4a_version=7.9.0-SNAPSHOT
+
+ se_commons_version=7.9.0-SNAPSHOT
  se_gradle_version=7.9.0-SNAPSHOT
- 
- antlr_version=4.12.0
 -- 
 2.47.1.windows.1
 


### PR DESCRIPTION
* split between previous and currently used version

(While the generator has the dependencies of the old runtime, the current runtime should use the current log version)