### PR TITLE
Improve VarDeclarationNameAlreadyDefinedInScope

### DIFF
--- a/monticore-grammar/src/main/java/de/monticore/statements/mcvardeclarationstatements/_cocos/VarDeclarationNameAlreadyDefinedInScope.java
+++ b/monticore-grammar/src/main/java/de/monticore/statements/mcvardeclarationstatements/_cocos/VarDeclarationNameAlreadyDefinedInScope.java
@@ -8,14 +8,13 @@ import de.se_rwth.commons.logging.Log;
 import java.util.List;
 
 /**
- * Checks whether the variable name has already been defined in the local scope.
- * Logs an error for _each_ variable declaration (with the same name).
+ * Checks whether the variable name has already been defined in the scope.
+ * In an ordered scope, an error will not be logged for the first defining variable.
  */
 public class VarDeclarationNameAlreadyDefinedInScope implements MCVarDeclarationStatementsASTVariableDeclaratorCoCo {
 
   /**
    * Indicates that the name of the variable has already been used in the scope
-   * This will produce one error for _each_ variable declaration (with the same name)
    */
   public static final String ERROR_CODE = "0xA0923";
 
@@ -33,22 +32,28 @@ public class VarDeclarationNameAlreadyDefinedInScope implements MCVarDeclaration
       return;
     }
 
-    List<VariableSymbol> localVarSymbols = node.getEnclosingScope().resolveVariableMany(
+    List<VariableSymbol> matchingCandidates = node.getEnclosingScope().resolveVariableMany(
         node.getDeclarator().getName()
     );
 
-    boolean hasPreviousDeclaration = localVarSymbols.stream().anyMatch(
-        v -> v != node.getDeclarator().getSymbol() &&
-            (!v.isPresentAstNode()
-            || !v.getAstNode().isPresent_SourcePositionStart()
-            || !node.isPresent_SourcePositionStart()
-            || v.getAstNode().get_SourcePositionStart().compareTo(node.get_SourcePositionStart()) < 0)
-    );
-
-    if (hasPreviousDeclaration) {
+    if (matchingCandidates.stream().anyMatch(v -> alreadyDefined(node, v))) {
       Log.error(ERROR_CODE + " " + String.format(ERROR_MSG_FORMAT,
           node.getDeclarator().getName()),
           node.get_SourcePositionStart(), node.get_SourcePositionEnd());
+    }
+  }
+
+  protected boolean alreadyDefined(ASTVariableDeclarator node, VariableSymbol o) {
+    if (node.getDeclarator().getSymbol() == o) return false;
+    if (node.getEnclosingScope().isOrdered() && node.getEnclosingScope() == o.getEnclosingScope()) {
+      // If the scope is ordered and both symbols are in the same scope the first defining location is not considered already defined
+      return !o.isPresentAstNode()
+          || !o.getAstNode().isPresent_SourcePositionStart()
+          || !node.isPresent_SourcePositionStart()
+          || o.getAstNode().get_SourcePositionStart().compareTo(node.get_SourcePositionStart()) < 0;
+    } else {
+      // if the scope is unordered the symbol is already defined
+      return true;
     }
   }
 }

--- a/monticore-grammar/src/main/java/de/monticore/statements/mcvardeclarationstatements/_cocos/VarDeclarationNameAlreadyDefinedInScope.java
+++ b/monticore-grammar/src/main/java/de/monticore/statements/mcvardeclarationstatements/_cocos/VarDeclarationNameAlreadyDefinedInScope.java
@@ -34,13 +34,15 @@ public class VarDeclarationNameAlreadyDefinedInScope implements MCVarDeclaration
     }
 
     List<VariableSymbol> localVarSymbols = node.getEnclosingScope().resolveVariableMany(
-        node.getDeclarator().getName(),
-        (v) -> v != node.getDeclarator().getSymbol()
+        node.getDeclarator().getName()
     );
 
     boolean hasPreviousDeclaration = localVarSymbols.stream().anyMatch(
-        v -> !v.isPresentAstNode()
-            || v.getAstNode().get_SourcePositionStart().compareTo(node.get_SourcePositionStart()) < 0
+        v -> v != node.getDeclarator().getSymbol() &&
+            (!v.isPresentAstNode()
+            || !v.getAstNode().isPresent_SourcePositionStart()
+            || !node.isPresent_SourcePositionStart()
+            || v.getAstNode().get_SourcePositionStart().compareTo(node.get_SourcePositionStart()) < 0)
     );
 
     if (hasPreviousDeclaration) {

--- a/monticore-grammar/src/main/java/de/monticore/statements/mcvardeclarationstatements/_cocos/VarDeclarationNameAlreadyDefinedInScope.java
+++ b/monticore-grammar/src/main/java/de/monticore/statements/mcvardeclarationstatements/_cocos/VarDeclarationNameAlreadyDefinedInScope.java
@@ -3,7 +3,6 @@ package de.monticore.statements.mcvardeclarationstatements._cocos;
 
 import de.monticore.statements.mcvardeclarationstatements._ast.ASTVariableDeclarator;
 import de.monticore.symbols.basicsymbols._symboltable.VariableSymbol;
-import de.monticore.symboltable.modifiers.AccessModifier;
 import de.se_rwth.commons.logging.Log;
 
 import java.util.List;
@@ -34,14 +33,17 @@ public class VarDeclarationNameAlreadyDefinedInScope implements MCVarDeclaration
       return;
     }
 
-    List<VariableSymbol> localVarSymbols = node.getEnclosingScope().resolveVariableLocallyMany(
-        false,
+    List<VariableSymbol> localVarSymbols = node.getEnclosingScope().resolveVariableMany(
         node.getDeclarator().getName(),
-        AccessModifier.ALL_INCLUSION,
         (v) -> v != node.getDeclarator().getSymbol()
     );
 
-    if (!localVarSymbols.isEmpty()) {
+    boolean hasPreviousDeclaration = localVarSymbols.stream().anyMatch(
+        v -> !v.isPresentAstNode()
+            || v.getAstNode().get_SourcePositionStart().compareTo(node.get_SourcePositionStart()) < 0
+    );
+
+    if (hasPreviousDeclaration) {
       Log.error(ERROR_CODE + " " + String.format(ERROR_MSG_FORMAT,
           node.getDeclarator().getName()),
           node.get_SourcePositionStart(), node.get_SourcePositionEnd());

--- a/monticore-grammar/src/test/java/de/monticore/statements/cocos/VarDeclarationNameAlreadyDefinedInScopeTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/statements/cocos/VarDeclarationNameAlreadyDefinedInScopeTest.java
@@ -6,6 +6,8 @@ import de.monticore.statements.mcvardeclarationstatements._symboltable.MCVarDecl
 import de.monticore.statements.testmcvardeclarationstatements.TestMCVarDeclarationStatementsMill;
 import de.monticore.statements.testmcvardeclarationstatements._ast.ASTRootVarDeclaration;
 import de.monticore.statements.testmcvardeclarationstatements._cocos.TestMCVarDeclarationStatementsCoCoChecker;
+import de.monticore.statements.testmcvardeclarationstatements._symboltable.ITestMCVarDeclarationStatementsScope;
+import de.monticore.statements.testmcvardeclarationstatements._symboltable.TestMCVarDeclarationStatementsScope;
 import de.monticore.statements.testmcvardeclarationstatements._visitor.TestMCVarDeclarationStatementsTraverser;
 import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
 import de.monticore.types3.util.CombineExpressionsWithLiteralsTypeTraverserFactory;
@@ -68,7 +70,6 @@ class VarDeclarationNameAlreadyDefinedInScopeTest {
 
     List<String> expected = List.of(
       VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE,
-      VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE,
       VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE
     );
 
@@ -99,6 +100,55 @@ class VarDeclarationNameAlreadyDefinedInScopeTest {
     // Then
     assertEquals(List.of(VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE), Log.getFindings()
       .stream().map(f -> f.getMsg().substring(0, 7)).collect(Collectors.toList())
+    );
+  }
+
+  @Test
+  void testInvalidVarDeclarationWithSymbolInSuperNonShadowingScope() throws IOException {
+    // Given
+    TestMCVarDeclarationStatementsCoCoChecker checker = new TestMCVarDeclarationStatementsCoCoChecker();
+    checker.addCoCo(new VarDeclarationNameAlreadyDefinedInScope());
+
+    ASTRootVarDeclaration astDecl = parseAndBuildAST("int a = 10;");
+    ITestMCVarDeclarationStatementsScope scope = TestMCVarDeclarationStatementsMill.scope();
+    astDecl.getEnclosingScope().getEnclosingScope().addSubScope(scope);
+    scope.addSubScope(astDecl.getEnclosingScope());
+    scope.add(TestMCVarDeclarationStatementsMill.variableSymbolBuilder()
+        .setName("a")
+        .setEnclosingScope(astDecl.getEnclosingScope())
+        .build());
+
+    // When
+    checker.checkAll(astDecl);
+
+    // Then
+    assertEquals(List.of(VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE), Log.getFindings()
+        .stream().map(f -> f.getMsg().substring(0, 7)).collect(Collectors.toList())
+    );
+  }
+
+  @Test
+  void testInvalidVarDeclarationWithSymbolInSuperShadowingScope() throws IOException {
+    // Given
+    TestMCVarDeclarationStatementsCoCoChecker checker = new TestMCVarDeclarationStatementsCoCoChecker();
+    checker.addCoCo(new VarDeclarationNameAlreadyDefinedInScope());
+
+    ASTRootVarDeclaration astDecl = parseAndBuildAST("int a = 10;");
+    ITestMCVarDeclarationStatementsScope scope = TestMCVarDeclarationStatementsMill.scope();
+    ((TestMCVarDeclarationStatementsScope) scope).setShadowing(true);
+    astDecl.getEnclosingScope().getEnclosingScope().addSubScope(scope);
+    scope.addSubScope(astDecl.getEnclosingScope());
+    scope.add(TestMCVarDeclarationStatementsMill.variableSymbolBuilder()
+        .setName("a")
+        .setEnclosingScope(astDecl.getEnclosingScope())
+        .build());
+
+    // When
+    checker.checkAll(astDecl);
+
+    // Then
+    assertEquals(List.of(VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE), Log.getFindings()
+        .stream().map(f -> f.getMsg().substring(0, 7)).collect(Collectors.toList())
     );
   }
 }

--- a/monticore-grammar/src/test/java/de/monticore/statements/cocos/VarDeclarationNameAlreadyDefinedInScopeTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/statements/cocos/VarDeclarationNameAlreadyDefinedInScopeTest.java
@@ -7,8 +7,6 @@ import de.monticore.statements.mcvardeclarationstatements._symboltable.MCVarDecl
 import de.monticore.statements.testmcvardeclarationstatements.TestMCVarDeclarationStatementsMill;
 import de.monticore.statements.testmcvardeclarationstatements._ast.ASTRootVarDeclaration;
 import de.monticore.statements.testmcvardeclarationstatements._cocos.TestMCVarDeclarationStatementsCoCoChecker;
-import de.monticore.statements.testmcvardeclarationstatements._symboltable.ITestMCVarDeclarationStatementsScope;
-import de.monticore.statements.testmcvardeclarationstatements._symboltable.TestMCVarDeclarationStatementsScope;
 import de.monticore.statements.testmcvardeclarationstatements._visitor.TestMCVarDeclarationStatementsTraverser;
 import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
 import de.monticore.types3.util.CombineExpressionsWithLiteralsTypeTraverserFactory;
@@ -18,14 +16,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
 
-import static de.monticore.runtime.junit.MCAssertions.assertHasFindingStartingWith;
-import static de.monticore.runtime.junit.MCAssertions.assertHasFindings;
-import static de.monticore.runtime.junit.MCAssertions.assertNoFindings;
 import static de.monticore.statements.testmcvardeclarationstatements.TestMCVarDeclarationStatementsMill.parser;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class VarDeclarationNameAlreadyDefinedInScopeTest {
 
@@ -81,6 +73,25 @@ class VarDeclarationNameAlreadyDefinedInScopeTest {
   }
 
   @Test
+  void testInvalidUnorderedMultiVarDeclaration() throws IOException {
+    // Given
+    TestMCVarDeclarationStatementsCoCoChecker checker = new TestMCVarDeclarationStatementsCoCoChecker();
+    checker.addCoCo(new VarDeclarationNameAlreadyDefinedInScope());
+
+    ASTRootVarDeclaration astDecl = parseAndBuildAST("int a = 10, a, a = -12;");
+    astDecl.getEnclosingScope().setOrdered(false);
+
+    // When
+    checker.checkAll(astDecl);
+
+    // Then
+    Log.getFindings().remove(MCAssertions.assertHasFindingStartingWith(VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE));
+    Log.getFindings().remove(MCAssertions.assertHasFindingStartingWith(VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE));
+    Log.getFindings().remove(MCAssertions.assertHasFindingStartingWith(VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE));
+    MCAssertions.assertNoFindings();
+  }
+
+  @Test
   void testInvalidVarDeclarationWithSymbolInScope() throws IOException {
     // Given
     TestMCVarDeclarationStatementsCoCoChecker checker = new TestMCVarDeclarationStatementsCoCoChecker();
@@ -129,7 +140,6 @@ class VarDeclarationNameAlreadyDefinedInScopeTest {
 
     ASTRootVarDeclaration astDecl = parseAndBuildAST("int a = 10;");
     astDecl.getEnclosingScope().setShadowing(true);
-
     TestMCVarDeclarationStatementsMill.globalScope().add(TestMCVarDeclarationStatementsMill.variableSymbolBuilder()
         .setName("a")
         .setEnclosingScope(astDecl.getEnclosingScope())

--- a/monticore-grammar/src/test/java/de/monticore/statements/cocos/VarDeclarationNameAlreadyDefinedInScopeTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/statements/cocos/VarDeclarationNameAlreadyDefinedInScopeTest.java
@@ -62,6 +62,7 @@ class VarDeclarationNameAlreadyDefinedInScopeTest {
     checker.addCoCo(new VarDeclarationNameAlreadyDefinedInScope());
 
     ASTRootVarDeclaration astDecl = parseAndBuildAST("int a = 10, a, a = -12;");
+    astDecl.getEnclosingScope().setOrdered(true);
 
     // When
     checker.checkAll(astDecl);

--- a/monticore-grammar/src/test/java/de/monticore/statements/cocos/VarDeclarationNameAlreadyDefinedInScopeTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/statements/cocos/VarDeclarationNameAlreadyDefinedInScopeTest.java
@@ -1,6 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.statements.cocos;
 
+import de.monticore.runtime.junit.MCAssertions;
 import de.monticore.statements.mcvardeclarationstatements._cocos.VarDeclarationNameAlreadyDefinedInScope;
 import de.monticore.statements.mcvardeclarationstatements._symboltable.MCVarDeclarationStatementsSTCompleteTypes;
 import de.monticore.statements.testmcvardeclarationstatements.TestMCVarDeclarationStatementsMill;
@@ -20,6 +21,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static de.monticore.runtime.junit.MCAssertions.assertHasFindingStartingWith;
+import static de.monticore.runtime.junit.MCAssertions.assertHasFindings;
 import static de.monticore.runtime.junit.MCAssertions.assertNoFindings;
 import static de.monticore.statements.testmcvardeclarationstatements.TestMCVarDeclarationStatementsMill.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,7 +41,7 @@ class VarDeclarationNameAlreadyDefinedInScopeTest {
 
   protected ASTRootVarDeclaration parseAndBuildAST(String decl) throws IOException {
     ASTRootVarDeclaration ast = parser().parse_StringRootVarDeclaration(decl).orElseThrow();
-    TestMCVarDeclarationStatementsMill.scopesGenitorDelegator().createFromAST(ast);
+    TestMCVarDeclarationStatementsMill.scopesGenitorDelegator().createFromAST(ast).setName("Artifact");
     TestMCVarDeclarationStatementsTraverser completerTraverser = TestMCVarDeclarationStatementsMill.traverser();
     completerTraverser.add4MCVarDeclarationStatements(new MCVarDeclarationStatementsSTCompleteTypes());
     ast.accept(completerTraverser);
@@ -57,7 +60,7 @@ class VarDeclarationNameAlreadyDefinedInScopeTest {
     checker.checkAll(astDecl);
 
     // Then
-    assertNoFindings();
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -68,18 +71,13 @@ class VarDeclarationNameAlreadyDefinedInScopeTest {
 
     ASTRootVarDeclaration astDecl = parseAndBuildAST("int a = 10, a, a = -12;");
 
-    List<String> expected = List.of(
-      VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE,
-      VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE
-    );
-
     // When
     checker.checkAll(astDecl);
 
     // Then
-    assertEquals(expected, Log.getFindings()
-      .stream().map(f -> f.getMsg().substring(0, 7)).collect(Collectors.toList())
-    );
+    Log.getFindings().remove(MCAssertions.assertHasFindingStartingWith(VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE));
+    Log.getFindings().remove(MCAssertions.assertHasFindingStartingWith(VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE));
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -98,9 +96,8 @@ class VarDeclarationNameAlreadyDefinedInScopeTest {
     checker.checkAll(astDecl);
 
     // Then
-    assertEquals(List.of(VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE), Log.getFindings()
-      .stream().map(f -> f.getMsg().substring(0, 7)).collect(Collectors.toList())
-    );
+    Log.getFindings().remove(MCAssertions.assertHasFindingStartingWith(VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE));
+    MCAssertions.assertNoFindings();
   }
 
   @Test
@@ -110,10 +107,8 @@ class VarDeclarationNameAlreadyDefinedInScopeTest {
     checker.addCoCo(new VarDeclarationNameAlreadyDefinedInScope());
 
     ASTRootVarDeclaration astDecl = parseAndBuildAST("int a = 10;");
-    ITestMCVarDeclarationStatementsScope scope = TestMCVarDeclarationStatementsMill.scope();
-    astDecl.getEnclosingScope().getEnclosingScope().addSubScope(scope);
-    scope.addSubScope(astDecl.getEnclosingScope());
-    scope.add(TestMCVarDeclarationStatementsMill.variableSymbolBuilder()
+    astDecl.getEnclosingScope().setShadowing(false);
+    TestMCVarDeclarationStatementsMill.globalScope().add(TestMCVarDeclarationStatementsMill.variableSymbolBuilder()
         .setName("a")
         .setEnclosingScope(astDecl.getEnclosingScope())
         .build());
@@ -122,23 +117,20 @@ class VarDeclarationNameAlreadyDefinedInScopeTest {
     checker.checkAll(astDecl);
 
     // Then
-    assertEquals(List.of(VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE), Log.getFindings()
-        .stream().map(f -> f.getMsg().substring(0, 7)).collect(Collectors.toList())
-    );
+    Log.getFindings().remove(MCAssertions.assertHasFindingStartingWith(VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE));
+    MCAssertions.assertNoFindings();
   }
 
   @Test
-  void testInvalidVarDeclarationWithSymbolInSuperShadowingScope() throws IOException {
+  void testValidVarDeclarationWithSymbolInSuperShadowingScope() throws IOException {
     // Given
     TestMCVarDeclarationStatementsCoCoChecker checker = new TestMCVarDeclarationStatementsCoCoChecker();
     checker.addCoCo(new VarDeclarationNameAlreadyDefinedInScope());
 
     ASTRootVarDeclaration astDecl = parseAndBuildAST("int a = 10;");
-    ITestMCVarDeclarationStatementsScope scope = TestMCVarDeclarationStatementsMill.scope();
-    ((TestMCVarDeclarationStatementsScope) scope).setShadowing(true);
-    astDecl.getEnclosingScope().getEnclosingScope().addSubScope(scope);
-    scope.addSubScope(astDecl.getEnclosingScope());
-    scope.add(TestMCVarDeclarationStatementsMill.variableSymbolBuilder()
+    astDecl.getEnclosingScope().setShadowing(true);
+
+    TestMCVarDeclarationStatementsMill.globalScope().add(TestMCVarDeclarationStatementsMill.variableSymbolBuilder()
         .setName("a")
         .setEnclosingScope(astDecl.getEnclosingScope())
         .build());
@@ -147,8 +139,6 @@ class VarDeclarationNameAlreadyDefinedInScopeTest {
     checker.checkAll(astDecl);
 
     // Then
-    assertEquals(List.of(VarDeclarationNameAlreadyDefinedInScope.ERROR_CODE), Log.getFindings()
-        .stream().map(f -> f.getMsg().substring(0, 7)).collect(Collectors.toList())
-    );
+    MCAssertions.assertNoFindings();
   }
 }


### PR DESCRIPTION
- Don't print an error message for the first definition if the definitions are in the same ordered scope
- Include parent scopes