### PR TITLE
Cache the DefaultObjectWrapper

### DIFF
--- a/monticore-runtime/src/main/java/de/monticore/generating/templateengine/freemarker/SimpleHashFactory.java
+++ b/monticore-runtime/src/main/java/de/monticore/generating/templateengine/freemarker/SimpleHashFactory.java
@@ -7,6 +7,7 @@ package de.monticore.generating.templateengine.freemarker;
 
 import de.monticore.generating.GeneratorSetup;
 import freemarker.log.Logger;
+import freemarker.template.DefaultObjectWrapper;
 import freemarker.template.DefaultObjectWrapperBuilder;
 import freemarker.template.ObjectWrapper;
 import freemarker.template.SimpleHash;
@@ -21,11 +22,18 @@ import java.util.Map;
 public class SimpleHashFactory {
 
   private static SimpleHashFactory theInstance;
+  protected DefaultObjectWrapper defaultObjectWrapper;
 
   protected SimpleHashFactory() {
     theInstance = this;
     // use empty logger to suppress default free marker log behaviour
     System.setProperty(Logger.SYSTEM_PROPERTY_NAME_LOGGER_LIBRARY, Logger.LIBRARY_NAME_NONE);
+
+    // Share the DefaultObjectWrapper (as it references the beans(available methods of a class)
+    DefaultObjectWrapperBuilder defaultObjectWrapperBuilder = new DefaultObjectWrapperBuilder(
+            GeneratorSetup.FREEMARKER_VERSION);
+    defaultObjectWrapperBuilder.setUseModelCache(true);
+    this.defaultObjectWrapper = defaultObjectWrapperBuilder.build();
   }
   
   public static SimpleHashFactory getInstance() {
@@ -36,17 +44,19 @@ public class SimpleHashFactory {
   }
   
   public SimpleHash createSimpleHash() {
-    return new SimpleHash(new DefaultObjectWrapperBuilder(GeneratorSetup.FREEMARKER_VERSION).build());
+    return new SimpleHash(defaultObjectWrapper);
   }
   
   public SimpleHash createSimpleHash(Map<?, ?> map) {
-    return new SimpleHash(map, new DefaultObjectWrapperBuilder(GeneratorSetup.FREEMARKER_VERSION).build());
+    return new SimpleHash(map, defaultObjectWrapper);
   }
-  
+
+  @Deprecated
   public SimpleHash createSimpleHash(ObjectWrapper wrapper) {
     return new SimpleHash(wrapper);
   }
-  
+
+  @Deprecated
   public SimpleHash createSimpleHash(Map<?, ?> map, ObjectWrapper wrapper) {
     return new SimpleHash(map, wrapper);
   }


### PR DESCRIPTION
<img width="1813" height="610" alt="grafik" src="https://github.com/user-attachments/assets/03eb16c0-2405-40e5-89fb-53af7a033bcd" />
Green: old  
Red: new


```diff
- root@openjdk-test:~/profile_cli/mc-workspace# time java -agentpath:/root/async/async-profiler-4.2-linux-x64/lib/libasyncProfiler.so=start,event=cpu,file=profile_gs_commonexpr.jfr,jfr -cp monticore.jar:../slf4j-simple-2.0.18.jar de.monticore.cli.MontiCoreTool -g ../grammars/de/monticore/expressions/CommonExpressions.mc4 -hcp hwc/ src/ -mp ../grammars/ -d
+ root@openjdk-test:~/profile_cli/mc-workspace# time java -agentpath:/root/async/async-profiler-4.2-linux-x64/lib/libasyncProfiler.so=start,event=cpu,file=profile_tool1_commonexpr.jfr,jfr -cp ../tool-ch1.jar:../slf4j-simple-2.0.18.jar de.monticore.cli.MontiCoreTool -g ../grammars/de/monticore/expressions/CommonExpressions.mc4 -hcp hwc/ src/ -mp ../grammars/ -d
- real    0m14.669s
+ real    0m10.337s
- user    0m42.616s
+ user    0m29.367s
- sys     0m1.362s
+ sys     0m1.210s
```

Actually caches the simplehash of objects and keeps their beans.