### PR TITLE
Fix for MCTypeFacade and creation types from a generic type

### DIFF
--- a/monticore-grammar/src/main/java/de/monticore/types/MCTypeFacade.java
+++ b/monticore-grammar/src/main/java/de/monticore/types/MCTypeFacade.java
@@ -17,7 +17,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * facade for creation of ASTMCTypes
+ * facade for creation of ASTMCTypes.
+ * In case the simple generic types are loaded, {@link de.monticore.types.mcsimplegenerictypes.MCSimpleGenericTypesMCTypeFacade} is used
  */
 public class MCTypeFacade {
 
@@ -25,12 +26,16 @@ public class MCTypeFacade {
 
   private static MCTypeFacade MCTypeFacade;
 
-  private MCTypeFacade() {
+  protected MCTypeFacade() {
+  }
+
+  protected static void setInstance(MCTypeFacade instance) {
+    MCTypeFacade = instance;
   }
 
   public static MCTypeFacade getInstance() {
     if (MCTypeFacade == null) {
-      MCTypeFacade = new MCTypeFacade();
+      setInstance(new MCTypeFacade());
     }
     return MCTypeFacade;
   }

--- a/monticore-grammar/src/main/java/de/monticore/types/mcsimplegenerictypes/MCSimpleGenericTypesMCTypeFacade.java
+++ b/monticore-grammar/src/main/java/de/monticore/types/mcsimplegenerictypes/MCSimpleGenericTypesMCTypeFacade.java
@@ -9,7 +9,7 @@ import de.monticore.types.mcfullgenerictypes.MCFullGenericTypesMill;
 
 /**
  * facade for creation of ASTMCTypes when simple generic types are supported.
- * Replaces al printType() using methods to use MCCustomTypeArguments instead
+ * Replaces all printType() using methods to use MCCustomTypeArguments instead
  */
 public class MCSimpleGenericTypesMCTypeFacade extends MCTypeFacade {
 

--- a/monticore-grammar/src/main/java/de/monticore/types/mcsimplegenerictypes/MCSimpleGenericTypesMCTypeFacade.java
+++ b/monticore-grammar/src/main/java/de/monticore/types/mcsimplegenerictypes/MCSimpleGenericTypesMCTypeFacade.java
@@ -1,0 +1,85 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.types.mcsimplegenerictypes;
+
+import com.google.common.collect.Lists;
+import de.monticore.types.MCTypeFacade;
+import de.monticore.types.mcbasictypes._ast.ASTMCType;
+import de.monticore.types.mccollectiontypes._ast.*;
+import de.monticore.types.mcfullgenerictypes.MCFullGenericTypesMill;
+
+/**
+ * facade for creation of ASTMCTypes when simple generic types are supported.
+ * Replaces al printType() using methods to use MCCustomTypeArguments instead
+ */
+public class MCSimpleGenericTypesMCTypeFacade extends MCTypeFacade {
+
+  @Override
+  public ASTMCListType createListTypeOf(final ASTMCType type) {
+    return createListTypeOf(createTypeArgument(type));
+  }
+
+  @Override
+  public ASTMCListType createListTypeOf(ASTMCTypeArgument type) {
+    var b = MCSimpleGenericTypesMill.mCListTypeBuilder();
+    b.setMCTypeArgument(type);
+    return b.build();
+  }
+
+  @Override
+  public ASTMCSetType createSetTypeOf(final ASTMCType type) {
+    return createSetTypeOf(createTypeArgument(type));
+  }
+
+  @Override
+  public ASTMCSetType createSetTypeOf(final ASTMCTypeArgument type) {
+    var b = MCSimpleGenericTypesMill.mCSetTypeBuilder();
+    b.setMCTypeArgument(type);
+    return b.build();
+  }
+
+  @Override
+  public ASTMCGenericType createCollectionTypeOf(final ASTMCType type) {
+    var b = MCSimpleGenericTypesMill.mCBasicGenericTypeBuilder();
+    b.setNamesList(Lists.newArrayList("Collection"));
+    b.addMCTypeArgument(createTypeArgument(type));
+    return b.build();
+  }
+
+
+  @Override
+  public ASTMCOptionalType createOptionalTypeOf(final ASTMCType type) {
+    return createOptionalTypeOf(createTypeArgument(type));
+  }
+
+  @Override
+  public ASTMCOptionalType createOptionalTypeOf(final ASTMCTypeArgument type) {
+    var b = MCSimpleGenericTypesMill.mCOptionalTypeBuilder();
+    b.setMCTypeArgument(type);
+    return b.build();
+  }
+
+  @Override
+  public ASTMCMapType createMapTypeOf(final ASTMCType firstType, final ASTMCType secondType) {
+    return createMapTypeOf(createTypeArgument(firstType), createTypeArgument(secondType));
+  }
+
+  @Override
+  public ASTMCMapType createMapTypeOf(final ASTMCTypeArgument firstType, final ASTMCTypeArgument secondType) {
+    return MCFullGenericTypesMill.mCMapTypeBuilder()
+            .setKey(firstType)
+            .setValue(secondType)
+            .build();
+  }
+
+  public ASTMCTypeArgument createTypeArgument(final ASTMCType type) {
+    return MCSimpleGenericTypesMill.mCCustomTypeArgumentBuilder().setMCType(type.deepClone()).build();
+  }
+
+  public static void initializeAsMCTypeFacade() {
+    setInstance(new MCSimpleGenericTypesMCTypeFacade());
+  }
+
+  public static void deinitializeAsMCTypeFacade() {
+    setInstance(null);
+  }
+}

--- a/monticore-grammar/src/main/java/de/monticore/types/mcsimplegenerictypes/MCSimpleGenericTypesMill.java
+++ b/monticore-grammar/src/main/java/de/monticore/types/mcsimplegenerictypes/MCSimpleGenericTypesMill.java
@@ -1,0 +1,26 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.types.mcsimplegenerictypes;
+
+public class MCSimpleGenericTypesMill extends MCSimpleGenericTypesMillTOP {
+  /**
+   * Initializes a languages Mill.
+   * This will also initialize the Mills of all languages it depends on.
+   * This ensures that all objects of this mill, such as builders, traversers, scopes, ..., deliver the element of the correct language.
+   */
+  public static void init() {
+    MCSimpleGenericTypesMillTOP.init();
+
+    // Add support for MCCustomTypeArguments to the MCTypeFacade
+    MCSimpleGenericTypesMCTypeFacade.initializeAsMCTypeFacade();
+  }
+
+  public static void initMe(MCSimpleGenericTypesMill a) {
+    MCSimpleGenericTypesMillTOP.initMe(a);
+    MCSimpleGenericTypesMCTypeFacade.initializeAsMCTypeFacade();
+  }
+
+  public static void reset() {
+    MCSimpleGenericTypesMillTOP.reset();
+    MCSimpleGenericTypesMCTypeFacade.deinitializeAsMCTypeFacade();
+  }
+}

--- a/monticore-grammar/src/test/java/de/monticore/types/MCSimpleGenericsTypeFacadeTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/types/MCSimpleGenericsTypeFacadeTest.java
@@ -1,0 +1,48 @@
+/* (c) https://github.com/MontiCore/monticore */
+package de.monticore.types;
+
+import de.monticore.runtime.junit.TestWithMCLanguage;
+import de.monticore.types.mcbasictypes._ast.ASTMCType;
+import de.monticore.types.mcsimplegenerictypes.MCSimpleGenericTypesMCTypeFacade;
+import de.monticore.types.mcsimplegenerictypes.MCSimpleGenericTypesMill;
+import de.monticore.types.mcsimplegenerictypes._ast.ASTMCBasicGenericType;
+import de.monticore.types.mcsimplegenerictypes._ast.ASTMCCustomTypeArgument;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@TestWithMCLanguage(MCSimpleGenericTypesMill.class)
+public class MCSimpleGenericsTypeFacadeTest extends MCTypeFacadeTest {
+  @Override
+  protected MCTypeFacade doCreateTypeFacade() {
+    MCSimpleGenericTypesMill.init();
+    return super.doCreateTypeFacade();
+  }
+
+  @Test
+  public void assertThatCorrectFacade() {
+    Assertions.assertInstanceOf(MCSimpleGenericTypesMCTypeFacade.class, this.mcTypeFacade);
+  }
+
+  @Test
+  public void testCustomInnerTypeArgument() {
+    // Without the custom type facade, printType() is used which causes
+    /* type = parser.parse_TypeString("IElem<MyInnerClass>");
+       MCTypeFacade.getInstance().createListTypeOf(type) */
+    // To be a qualifiedType("IElem<MyInnerClass>"), which is just incorrect
+    ASTMCType myType = MCSimpleGenericTypesMill.mCBasicGenericTypeBuilder()
+            .addName("IElem")
+            .addMCTypeArgument(
+                    MCTypeFacade.getInstance().createBasicTypeArgumentOf("MyInnerClass"))
+            .build();
+    ASTMCType collection = MCTypeFacade.getInstance().createCollectionTypeOf(myType);
+
+    Assertions.assertInstanceOf(ASTMCBasicGenericType.class, collection);
+    Assertions.assertEquals("Collection", ((ASTMCBasicGenericType) collection).getName(0));
+    Assertions.assertInstanceOf(ASTMCCustomTypeArgument.class, ((ASTMCBasicGenericType) collection).getMCTypeArgument(0));
+    Assertions.assertTrue(((ASTMCBasicGenericType) collection).getMCTypeArgument(0).getMCTypeOpt().isPresent());
+    Assertions.assertTrue(myType.deepEquals(((ASTMCBasicGenericType) collection).getMCTypeArgument(0).getMCTypeOpt().get()));
+  }
+
+
+  // Other tests are extended from the MCTypeFacadeTest
+}

--- a/monticore-grammar/src/test/java/de/monticore/types/MCSimpleGenericsTypeFacadeTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/types/MCSimpleGenericsTypeFacadeTest.java
@@ -43,6 +43,5 @@ public class MCSimpleGenericsTypeFacadeTest extends MCTypeFacadeTest {
     Assertions.assertTrue(myType.deepEquals(((ASTMCBasicGenericType) collection).getMCTypeArgument(0).getMCTypeOpt().get()));
   }
 
-
   // Other tests are extended from the MCTypeFacadeTest
 }

--- a/monticore-grammar/src/test/java/de/monticore/types/MCTypeFacadeTest.java
+++ b/monticore-grammar/src/test/java/de/monticore/types/MCTypeFacadeTest.java
@@ -19,13 +19,17 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class MCTypeFacadeTest {
 
-  private MCTypeFacade mcTypeFacade;
+  protected MCTypeFacade mcTypeFacade;
 
   @BeforeEach
   public void init() {
     LogStub.init();
     Log.enableFailQuick(false);
-    this.mcTypeFacade = MCTypeFacade.getInstance();
+    this.mcTypeFacade = doCreateTypeFacade();
+  }
+
+  protected MCTypeFacade doCreateTypeFacade() {
+    return MCTypeFacade.getInstance();
   }
 
   @Test

--- a/prepare-next-release/0001-use-next-snapshot.patch
+++ b/prepare-next-release/0001-use-next-snapshot.patch
@@ -1,14 +1,14 @@
-From 2f136cf943c05d30a63ed1bd8d6037bf7d51643f Mon Sep 17 00:00:00 2001
+From c9ef3194706e1039c92f673bac19dde18801e984 Mon Sep 17 00:00:00 2001
 From: Janik Rapp <rapp@se-rwth.de>
 Date: Wed, 18 Mar 2026 12:53:07 +0100
 Subject: [PATCH] use next snapshot
 
 
 diff --git a/gradle.properties b/gradle.properties
-index 3d6263242..afdf8f7d1 100644
+index ca7a928e1..62e24a8ca 100644
 --- a/gradle.properties
 +++ b/gradle.properties
-@@ -16,10 +16,10 @@ org.gradle.caching=true
+@@ -16,11 +16,11 @@ org.gradle.caching=true
  # org.gradle.caching.debug=true
  
  # versions used
@@ -16,15 +16,17 @@ index 3d6263242..afdf8f7d1 100644
 -previous_mc_version=7.9.0
 -previous_se_commons_version=7.9.0
 -previous_cd4a_version=7.9.0
+-previous_class2mc_version=7.9.1
 +version=7.11.0-SNAPSHOT
 +previous_mc_version=7.10.0-SNAPSHOT
 +previous_se_commons_version=7.10.0-SNAPSHOT
 +previous_cd4a_version=7.10.0-SNAPSHOT
++previous_class2mc_version=7.10.0-SNAPSHOT
  
  se_commons_version=7.10.0-SNAPSHOT
  se_gradle_version=7.10.0-SNAPSHOT
 diff --git a/monticore-generator/gradle.properties b/monticore-generator/gradle.properties
-index 2c7feb45a..18e97ffeb 100644
+index 0982ff59d..5e1a0490f 100644
 --- a/monticore-generator/gradle.properties
 +++ b/monticore-generator/gradle.properties
 @@ -9,10 +9,10 @@ useLocalRepo=false


### PR DESCRIPTION
```
ASTMCType t = parser.parse_TypeString("IElem<IStateElem>");
MCTypeFacade.getInstance().createListTypeOf(t)
```

did not work (due to creating a QualifiedType(parts=["IElem<IStateElem>"]), which fails in very fancy ways